### PR TITLE
switch system tests to run with PhantomJS (poltergeist)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ services:
 script:
   - bundle exec rails db:drop
   - bundle exec rails db:create
-  - bundle exec rails db:setup
+  - bundle exec rails db:migrate
   - bundle exec rails test

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ group :development, :test do
   gem 'factory_girl_rails'
   gem 'listen'
   gem 'overcommit', require: false
+  gem 'poltergeist'
   gem 'pry-byebug'
   gem 'pry-rails'
   gem 'rubocop', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,8 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.5.1)
+      public_suffix (~> 2.0, >= 2.0.2)
     airbrussh (1.1.2)
       sshkit (>= 1.6.1, != 1.7.0)
     arel (8.0.0)
@@ -88,8 +90,16 @@ GEM
     capistrano-rbenv-install (1.2.0)
       capistrano (>= 3.0)
       capistrano-rbenv (>= 2.0)
+    capybara (2.13.0)
+      addressable
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
     childprocess (0.6.3)
       ffi (~> 1.0, >= 1.0.11)
+    cliver (0.3.2)
     coderay (1.1.1)
     coffee-rails (4.2.1)
       coffee-script (>= 2.2.0)
@@ -171,6 +181,10 @@ GEM
     parser (2.4.0.0)
       ast (~> 2.2)
     pg (0.20.0)
+    poltergeist (1.14.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      websocket-driver (>= 0.2.0)
     powerpack (0.1.1)
     pry (0.10.4)
       coderay (~> 1.1.0)
@@ -181,6 +195,7 @@ GEM
       pry (~> 0.10)
     pry-rails (0.3.6)
       pry (>= 0.10.4)
+    public_suffix (2.0.5)
     puma (3.8.2)
     pundit (1.1.0)
       activesupport (>= 3.0.0)
@@ -277,6 +292,8 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    xpath (2.0.0)
+      nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
@@ -294,6 +311,7 @@ DEPENDENCIES
   overcommit
   panter-rails-deploy
   pg
+  poltergeist
   pry-byebug
   pry-rails
   puma

--- a/README.md
+++ b/README.md
@@ -14,10 +14,16 @@ Ruby version: 2.4.1
 
 - [overcommit](https://github.com/brigade/overcommit)
 - [rubocop](https://github.com/bbatsov/rubocop)
+- [PhantomJS](http://phantomjs.org/download.html)
 
+### Install PhantomJS
+
+*MacOS with Homebrew*: `brew install phantomjs`
+*Debian (and similars):* 'apt-get install phantomjs'
+*Download and install manually*: http://phantomjs.org/download.html
 
 ## LICENSE
 
-All the sources created are made available under the terms 
-of the GNU Affero General Public License (GNU AGPLv3). 
+All the sources created are made available under the terms
+of the GNU Affero General Public License (GNU AGPLv3).
 See the GNU-AGPL-3.0.txt file for more details.

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,5 +1,6 @@
 require "test_helper"
+require 'capybara/poltergeist'
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :chrome, screen_size: [1400, 1400]
+  driven_by :poltergeist, screen_size: [1400, 1400]
 end


### PR DESCRIPTION
Introduce phantomjs tests with poltergeist in order to get headless system tests for Travis CI.