### PR TITLE
fix show profile link to lead to new_profile_path in case user has none

### DIFF
--- a/app/views/application/_navigation.html.slim
+++ b/app/views/application/_navigation.html.slim
@@ -21,6 +21,9 @@ nav.navbar.navbar-top
               span.caret
             ul.dropdown-menu
               li
-                = link_to 'Show profile', current_user.profile
+                - if current_user.profile.blank?
+                  = link_to 'Show profile', new_profile_path
+                - else
+                  = link_to 'Show profile', current_user.profile
               li
                 = link_to 'Logout', destroy_user_session_path, method: :delete

--- a/app/views/application/_navigation.html.slim
+++ b/app/views/application/_navigation.html.slim
@@ -22,7 +22,7 @@ nav.navbar.navbar-top
             ul.dropdown-menu
               li
                 - if current_user.profile.blank?
-                  = link_to 'Show profile', new_profile_path
+                  = link_to 'Create profile', new_profile_path
                 - else
                   = link_to 'Show profile', current_user.profile
               li

--- a/test/system/profiles_test.rb
+++ b/test/system/profiles_test.rb
@@ -78,4 +78,13 @@ class ProfilesTest < ApplicationSystemTestCase
     assert user.valid_password? 'abcdefghijk'
     assert_equal user.email, 'new@email.com'
   end
+
+  test 'profileless user gets new profile link on show profile' do
+    login_as @user_without_profile
+    visit user_path(@user_without_profile)
+    click_link @user_without_profile.email
+    assert page.has_link? 'Create profile'
+    click_link 'Create profile'
+    assert page.has_text? 'New profile'
+  end
 end


### PR DESCRIPTION
## Story
Link to trello story

## Informations

## Goals
- [x] Story is tested
- [x] Acceptance criterias are met
- [ ] Code is reviewed
- [x] Travis is green
- [x] Story is on resolved in trello
- [x] Readme is updated if needed
- [x] Styled with Bootstrap v3
- [x] Mobile view is usable
- [ ] Seeds are available
- [ ] German translations available
