### PR TITLE
fixing wrong path for user profile in departments

### DIFF
--- a/app/views/departments/show.html.slim
+++ b/app/views/departments/show.html.slim
@@ -17,7 +17,7 @@
     .col-xs-12
       ul
         - @department.user.each do |user|
-          li= link_to user.to_label, profile_path(user)
+          li= link_to user.to_label, profile_path(user.profile)
 
 = form_navigation_btn :edit
 = form_navigation_btn :back


### PR DESCRIPTION
It was a quite mean bug because it doesn't bang in most cases.
Why:
Profile and User are almost always saved together. So on a fresh DB they will also almost always turn out to have the same `id`. Almost... ;)
And that's wat was not the case on the staging server, so linking like that didn't work there, but on our dev machines, it did.