### PR TITLE
fix the not working and obsolete full_name concern

### DIFF
--- a/app/models/concerns/full_name.rb
+++ b/app/models/concerns/full_name.rb
@@ -1,9 +1,0 @@
-module FullName
-  extend ActiveSupport::Concern
-
-  included do
-    def full_name
-      "#{first_name} #{last_name}"
-    end
-  end
-end

--- a/app/models/relative.rb
+++ b/app/models/relative.rb
@@ -1,5 +1,4 @@
 class Relative < ApplicationRecord
-  include FullName
   include YearCollection
 
   belongs_to :relativeable, polymorphic: true, optional: true
@@ -7,6 +6,10 @@ class Relative < ApplicationRecord
   def to_s
     relation_human = relation ? I18n.t(relation, scope: [:relation]) : ''
     [full_name, date_of_birth.try(:year), relation_human].reject(&:blank?).join(', ')
+  end
+
+  def full_name
+    "#{first_name} #{last_name}"
   end
 
   def self.relation_collection

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -1,7 +1,7 @@
 class Volunteer < ApplicationRecord
   include AssociatableFields
   include GenderCollection
-  include FullName
+
   acts_as_paranoid
   before_save :default_state
 


### PR DESCRIPTION
This concern was actually only working in the Relatives model as is:

```ruby
def full_name
  "#{first_name} #{last_name}"
end
```

In User and Volunteer, it could only crash the app, because:
```ruby
@user.profile.contact.first_name
@volunteer.contact.first_name
@relative.first_name
```
And, it was included into Volunteer as this, and it only didn't crash everything, because it was never used inside the Volunteer model. So remove it from Volunteer and put the working method to User and Relative.

Or in other words: **it was rather a bug, then a concern** ;)