### PR TITLE
removing concern used only in client and rename the other

### DIFF
--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -1,6 +1,5 @@
 class Client < ApplicationRecord
-  include AssociatableFields
-  include AssociateRelatives
+  include LanguageAndScheduleReferences
   include GenderCollection
   include RequestCollection
   include YearCollection
@@ -16,6 +15,9 @@ class Client < ApplicationRecord
 
   has_one :contact, as: :contactable
   accepts_nested_attributes_for :contact
+
+  has_many :relatives, as: :relativeable, dependent: :destroy
+  accepts_nested_attributes_for :relatives, allow_destroy: true
 
   validates :state, inclusion: { in: STATES }
 

--- a/app/models/concerns/associate_relatives.rb
+++ b/app/models/concerns/associate_relatives.rb
@@ -1,8 +1,0 @@
-module AssociateRelatives
-  extend ActiveSupport::Concern
-
-  included do
-    has_many :relatives, as: :relativeable, dependent: :destroy
-    accepts_nested_attributes_for :relatives, allow_destroy: true
-  end
-end

--- a/app/models/concerns/language_and_schedule_references.rb
+++ b/app/models/concerns/language_and_schedule_references.rb
@@ -1,4 +1,4 @@
-module AssociatableFields
+module LanguageAndScheduleReferences
   extend ActiveSupport::Concern
 
   included do

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -1,5 +1,5 @@
 class Volunteer < ApplicationRecord
-  include AssociatableFields
+  include LanguageAndScheduleReferences
   include GenderCollection
   include FullName
   acts_as_paranoid


### PR DESCRIPTION
removing concern used only in client and rename the other …
- associate relatives concern was only used in Client, so it
  should be dropped and put into the client itself
- renaming the associatable_fields concern to a name that says
  what the thing actually does

