### PR TITLE
add rejection fields to the params and show

### DIFF
--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -69,7 +69,7 @@ class VolunteersController < ApplicationController
   end
 
   def volunteer_params
-    params.require(:volunteer).permit(volunteer_attributes, :trial_period, :intro_course,
-      :doc_sent, :bank_account, :evaluation)
+    params.require(:volunteer).permit(volunteer_attributes, :rejection_type, :rejection_text,
+      :trial_period, :intro_course, :doc_sent, :bank_account, :evaluation)
   end
 end

--- a/test/system/volunteers_test.rb
+++ b/test/system/volunteers_test.rb
@@ -150,12 +150,14 @@ class VolunteersTest < ApplicationSystemTestCase
     refute page.has_field? 'Explanation for rejection'
     select('Rejected', from: 'State')
     assert page.has_content? 'Reason for rejection'
+    page.choose('volunteer_rejection_type_other')
     assert page.has_field? 'Explanation for rejection'
+    fill_in 'Explanation for rejection', with: 'Explanation'
     click_button 'Update Volunteer'
 
     visit volunteer_path(volunteer)
-    assert page.has_content? 'Reason for rejection'
-    assert page.has_content? 'Explanation for rejection'
+    assert page.has_content? 'Reason for rejection Other'
+    assert page.has_content? 'Explanation for rejection Explanation'
   end
 
   test 'change filter to other options' do


### PR DESCRIPTION
# [Story in Trello](https://trello.com/c/NJp3qdtw/75-bug-volunteer-rejection-reason-and-type-are-not-saved-because-the-fields-are-not-in-the-permitted-params)

## Done?

### Done for approval?

* [x] Acceptance criteria are met
* [x] Code quality checks are green
* ~[ ] Readme updated if needed~
* [x] Story under test
* [x] Mobile works
* ~[ ] Seeds created~
* ~[ ] Translated~
* [x] Code is reviewed

### Done after the merge?

* [ ] Deployed to staging after the merge
* [ ] Tested manually on staging
