### PR TITLE
language level view on client/volunteer show and index

### DIFF
--- a/app/models/language_skill.rb
+++ b/app/models/language_skill.rb
@@ -11,7 +11,7 @@ class LanguageSkill < ApplicationRecord
   end
 
   def full_language_skills
-    level_human = level ? I18n.t(level, scope: [:language_level]) : ''
-    [language_name, level_human].reject(&:blank?).join(', ')
+    level_human = level? ? I18n.t(level, scope: [:language_level]) : ''
+    [language_name, level_human].reject(&:blank?).join(', ') if language?
   end
 end

--- a/app/views/language_skills/_show.html.slim
+++ b/app/views/language_skills/_show.html.slim
@@ -6,4 +6,5 @@ tr
         - speaker.language_skills.each do |language|
           - if language.language_name.present?
             dt= language.language_name
-            dd= t("language_level.#{language.level}")
+            - if language.level?
+              dd= t("language_level.#{language.level}")

--- a/test/system/clients_test.rb
+++ b/test/system/clients_test.rb
@@ -79,11 +79,11 @@ class ClientsTest < ApplicationSystemTestCase
     click_button 'Create Client'
     assert page.has_text? 'Client was successfully created.'
     within '.table-no-border-top' do
-      assert page.has_text? 'Dari'
+      assert page.has_text? 'Dari Native speaker'
     end
   end
 
-  test 'language without a level is shown' do
+  test 'language without a level shows only language' do
     visit new_client_path
     fill_in 'First name', with: 'asdf'
     fill_in 'Last name', with: 'asdf'

--- a/test/system/clients_test.rb
+++ b/test/system/clients_test.rb
@@ -105,6 +105,28 @@ class ClientsTest < ApplicationSystemTestCase
     assert page.has_text? 'Farsi'
   end
 
+  test 'level without a language is not shown' do
+    visit new_client_path
+    fill_in 'First name', with: 'asdf'
+    fill_in 'Last name', with: 'asdf'
+    fill_in 'Street', with: 'Sihlstrasse 131'
+    fill_in 'Zip', with: '8002'
+    fill_in 'City', with: 'Zürich'
+    fill_in 'Primary email', with: 'gurke@gurkenmail.com'
+    fill_in 'Primary phone', with: '0123456789'
+
+    click_on('Add language')
+    select('Fluent', from: 'Level')
+
+    click_button 'Create Client'
+    within '.table-no-border-top' do
+      refute page.has_text? 'Fluent'
+    end
+
+    visit clients_path
+    refute page.has_text? 'Fluent'
+  end
+
   test 'superadmin can delete client' do
     create :client
     visit clients_path

--- a/test/system/clients_test.rb
+++ b/test/system/clients_test.rb
@@ -79,8 +79,30 @@ class ClientsTest < ApplicationSystemTestCase
     click_button 'Create Client'
     assert page.has_text? 'Client was successfully created.'
     within '.table-no-border-top' do
-      assert page.has_text? 'Dari Native speaker'
+      assert page.has_text? 'Dari'
     end
+  end
+
+  test 'language without a level is shown' do
+    visit new_client_path
+    fill_in 'First name', with: 'asdf'
+    fill_in 'Last name', with: 'asdf'
+    fill_in 'Street', with: 'Sihlstrasse 131'
+    fill_in 'Zip', with: '8002'
+    fill_in 'City', with: 'Zürich'
+    fill_in 'Primary email', with: 'gurke@gurkenmail.com'
+    fill_in 'Primary phone', with: '0123456789'
+
+    click_on('Add language')
+    select('Farsi', from: 'Language')
+
+    click_button 'Create Client'
+    within '.table-no-border-top' do
+      refute page.has_text? ':native_speaker=>"Native speaker"'
+    end
+
+    visit clients_path
+    assert page.has_text? 'Farsi'
   end
 
   test 'superadmin can delete client' do


### PR DESCRIPTION
# [Story in Trello](https://trello.com/c/bTtadwGc/71-bug-language-without-level-results-in-i18n-argument-error-at-index-and-printing-of-the-level-hash-in-show)

## Done?

### Done for approval?

* [x] Acceptance criteria are met
* [x] Code quality checks are green
* ~[ ] Readme updated if needed~
* [x] Story under test
* [x] Mobile works
* ~[ ] Seeds created~
* ~[ ] Translated~
* [x] Code is reviewed

### Done after the merge?

* [ ] Deployed to staging after the merge
* [ ] Tested manually on staging
