### PR TITLE
Fix to imports: Volunteers and Clients get status from t_RollenEnde plus bugfix with language_skills

### DIFF
--- a/app/models/concerns/language_and_schedule_references.rb
+++ b/app/models/concerns/language_and_schedule_references.rb
@@ -7,10 +7,7 @@ module LanguageAndScheduleReferences
 
     delegate :native_languages, to: :language_skills
     delegate :foreign_languages, to: :language_skills
-
-    def native_language
-      native_languages.first || LanguageSkill.new
-    end
+    delegate :native_language, to: :language_skills
 
     has_many :schedules, as: :scheduleable, dependent: :destroy
     accepts_nested_attributes_for :schedules

--- a/app/models/concerns/language_and_schedule_references.rb
+++ b/app/models/concerns/language_and_schedule_references.rb
@@ -5,6 +5,13 @@ module LanguageAndScheduleReferences
     has_many :language_skills, as: :languageable, dependent: :destroy
     accepts_nested_attributes_for :language_skills, allow_destroy: true
 
+    delegate :native_languages, to: :language_skills
+    delegate :foreign_languages, to: :language_skills
+
+    def native_language
+      native_languages.first || LanguageSkill.new
+    end
+
     has_many :schedules, as: :scheduleable, dependent: :destroy
     accepts_nested_attributes_for :schedules
 

--- a/app/models/language_skill.rb
+++ b/app/models/language_skill.rb
@@ -1,13 +1,20 @@
 class LanguageSkill < ApplicationRecord
   belongs_to :languageable, polymorphic: true, optional: true
 
+  LANGUAGE_LEVELS = [:native_speaker, :fluent, :good, :basic].freeze
+
   scope :native_languages, lambda {
     where(level: 'native_speaker')
       .order("CASE WHEN language = 'DE' THEN 1 WHEN language != 'DE' THEN 2 END")
   }
-  scope :foreign_languages, -> { where.not(id: native_languages.first&.id) }
+  scope :foreign_languages, lambda {
+    return none unless native_language.id
+    where.not(id: native_language.id)
+  }
 
-  LANGUAGE_LEVELS = [:native_speaker, :fluent, :good, :basic].freeze
+  def self.native_language
+    native_languages.first || LanguageSkill.new
+  end
 
   def language_name
     return '' if language.blank?

--- a/app/models/language_skill.rb
+++ b/app/models/language_skill.rb
@@ -1,6 +1,12 @@
 class LanguageSkill < ApplicationRecord
   belongs_to :languageable, polymorphic: true, optional: true
 
+  scope :native_languages, lambda {
+    where(level: 'native_speaker')
+      .order("CASE WHEN language = 'DE' THEN 1 WHEN language != 'DE' THEN 2 END")
+  }
+  scope :foreign_languages, -> { where.not(id: native_languages.first&.id) }
+
   LANGUAGE_LEVELS = [:native_speaker, :fluent, :good, :basic].freeze
 
   def language_name

--- a/app/views/volunteers/_volunteer.html.slim
+++ b/app/views/volunteers/_volunteer.html.slim
@@ -6,8 +6,8 @@ tr
   td = volunteer.contact.postal_code
   td = volunteer.contact.primary_email
   td = volunteer.birth_year.year if volunteer.birth_year?
-  td = volunteer.language_skills.first.language_name if volunteer.language_skills.any?
-  td = render 'language_skills/show_inline', language_skills: volunteer.language_skills
+  td = volunteer.native_language&.language_name
+  td = render 'language_skills/show_inline', language_skills: volunteer.foreign_languages
   td = volunteer.education
   td = volunteer.profession
   td #{volunteer.working_percent}%

--- a/db/migrate/20170807101812_add_originating_entity_to_imports.rb
+++ b/db/migrate/20170807101812_add_originating_entity_to_imports.rb
@@ -1,0 +1,5 @@
+class AddOriginatingEntityToImports < ActiveRecord::Migration[5.1]
+  def change
+    add_column :imports, :base_origin_entity, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170803113154) do
+ActiveRecord::Schema.define(version: 20170807101812) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -94,6 +94,7 @@ ActiveRecord::Schema.define(version: 20170803113154) do
     t.datetime "deleted_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "base_origin_entity"
     t.index ["access_id"], name: "index_imports_on_access_id"
     t.index ["deleted_at"], name: "index_imports_on_deleted_at"
     t.index ["importable_type", "importable_id"], name: "index_imports_on_importable_type_and_importable_id"

--- a/lib/access_import/acc_utils.rb
+++ b/lib/access_import/acc_utils.rb
@@ -61,13 +61,11 @@ module AccUtils
     }
   end
 
-  def access_import(main_entity, pk_main_entity, *related_rows)
+  def access_import(main_entity_name, main_access_id, related_rows)
     {
-      access_id: main_entity[pk_main_entity],
-      store: {
-        main_entity: down_hkeys(main_entity),
-        related_rows: related_rows.map { |r| down_hkeys(r) }
-      }
+      access_id: main_access_id,
+      base_origin_entity: main_entity_name.to_s,
+      store: related_rows
     }
   end
 

--- a/lib/access_import/access_import.rb
+++ b/lib/access_import/access_import.rb
@@ -52,10 +52,11 @@ class AccessImport
   end
 
   def instantiate_all_accessors
-    Dir['lib/access_import/accessors/*.rb'].map do |file|
-      File.basename(file, '.*').camelize.constantize.new(@acdb) unless file.include? 'accessor.rb'
-    end.compact
-  end
+    Dir['lib/access_import/accessors/*.rb']
+      .reject { |file| File.basename(file, '.*') == 'accessor' }.map do |file|
+        File.basename(file, '.*').camelize.constantize.new(@acdb)
+      end
+  endFile.basename(file, '.*') == 'accessor'
 
   def make_class_variables(*accessors)
     accessors.each do |accessor|

--- a/lib/access_import/access_import.rb
+++ b/lib/access_import/access_import.rb
@@ -52,11 +52,9 @@ class AccessImport
   end
 
   def instantiate_all_accessors
-    Dir['lib/access_import/accessors/*.rb']
-      .reject { |file| file.slice(-11..-1) == 'accessor.rb' }
-      .map do |file|
-        file.split('/').last.slice(0..-4).camelize.constantize.new(@acdb)
-      end
+    Dir.entries('lib/access_import/accessors').slice(2..-1).map do |file|
+      file.slice(0..-4).camelize.constantize.new(@acdb) unless file == 'accessor.rb'
+    end.compact
   end
 
   def make_class_variables(*accessors)

--- a/lib/access_import/access_import.rb
+++ b/lib/access_import/access_import.rb
@@ -52,8 +52,8 @@ class AccessImport
   end
 
   def instantiate_all_accessors
-    Dir.entries('lib/access_import/accessors').slice(2..-1).map do |file|
-      file.slice(0..-4).camelize.constantize.new(@acdb) unless file == 'accessor.rb'
+    Dir['lib/access_import/accessors/*.rb'].map do |file|
+      File.basename(file, '.*').camelize.constantize.new(@acdb) unless file.include? 'accessor.rb'
     end.compact
   end
 

--- a/lib/access_import/access_import.rb
+++ b/lib/access_import/access_import.rb
@@ -20,6 +20,8 @@ class AccessImport
       ).any?
       client_attrs = client_transformer.prepare_attributes(ac_client)
       client = Client.new(client_attrs)
+      client.created_at = ac_client[:d_Rollenbeginn]
+      client.updated_at = ac_client[:d_MutDatum]
       client.user = User.first
       puts "Importing personen_rolle #{key} to Client.id: #{client.id}" if client.save!
     end
@@ -35,6 +37,8 @@ class AccessImport
       ).any?
       volunteer_attrs = volunteer_transformer.prepare_attributes(ac_volunteer)
       volunteer = Volunteer.new(volunteer_attrs)
+      volunteer.created_at = ac_volunteer[:d_Rollenbeginn]
+      volunteer.updated_at = ac_volunteer[:d_MutDatum]
       puts "Importing personen_rolle #{key} to Volunteer.id: #{volunteer.id}" if volunteer.save!
     end
     puts "Imported #{Volunteer.count - count_before_import} new volunteers from MS Access Datbase."

--- a/lib/access_import/access_import.rb
+++ b/lib/access_import/access_import.rb
@@ -53,10 +53,12 @@ class AccessImport
 
   def instantiate_all_accessors
     Dir['lib/access_import/accessors/*.rb']
-      .reject { |file| File.basename(file, '.*') == 'accessor' }.map do |file|
-        File.basename(file, '.*').camelize.constantize.new(@acdb)
+      .map { |file| File.basename(file, '.*') }
+      .reject { |name| name == 'accessor' }
+      .map do |name|
+        name.camelize.constantize.new(@acdb)
       end
-  endFile.basename(file, '.*') == 'accessor'
+  end
 
   def make_class_variables(*accessors)
     accessors.each do |accessor|

--- a/lib/access_import/accessors/accessor.rb
+++ b/lib/access_import/accessors/accessor.rb
@@ -22,50 +22,46 @@ class Accessor
     all[id.to_i]
   end
 
-  SEMESTER = [
-    [1, { semester: 'Frühling / Sommer', rolle: 'Animator/in' }],
-    [2, { semester: 'Herbst / Winter', rolle: 'Animator/in' }],
-    [3, { semester: '1. Halbjahr', rolle: 'Freiwillige/r' }],
-    [4, { semester: '2. Halbjahr', rolle: 'Freiwillige/r' }]
-  ].to_h.freeze
+  SEMESTER = {
+    1 => { semester: 'Frühling / Sommer', rolle: 'Animator/in' },
+    2 => { semester: 'Herbst / Winter', rolle: 'Animator/in' },
+    3 => { semester: '1. Halbjahr', rolle: 'Freiwillige/r' },
+    4 => { semester: '2. Halbjahr', rolle: 'Freiwillige/r' }
+  }.freeze
 
-  FREIWILLIGEN_FUNKTIONEN = [
-    nil,
-    'Begleitung',
-    'Kurs',
-    'Animation F',
-    'Kurzeinsatz',
-    'Andere',
-    'Animation A'
-  ].freeze
+  FREIWILLIGEN_FUNKTIONEN = {
+    1 => 'Begleitung',
+    2 => 'Kurs',
+    3 => 'Animation F',
+    4 => 'Kurzeinsatz',
+    5 => 'Andere',
+    6 => 'Animation A'
+  }.freeze
 
-  LEHRMITTEL = [
-    nil,
-    'ABC 1 - Alphabetisierung für Erwachsene',
-    'ABC 2 - Alphabetisierung für Erwachsene',
-    'Vorstufe Deutsch 1',
-    'Vorstufe Deutsch 2'
-  ].freeze
+  LEHRMITTEL = {
+    1 => 'ABC 1 - Alphabetisierung für Erwachsene',
+    2 => 'ABC 2 - Alphabetisierung für Erwachsene',
+    3 => 'Vorstufe Deutsch 1',
+    4 => 'Vorstufe Deutsch 2'
+  }.freeze
 
-  AUSBILDUNGS_TYPEN = [
-    nil,
-    '<keine>',
-    'Primarschule',
-    'Sekundarschule',
-    'Fachmittelschule',
-    'Fahhochschule',
-    'Gymnasium',
-    'GEP-Einsatz',
-    'EBA Eidg. Berufsattest',
-    'eidg. Anerkannte Berufslehre'
-  ].freeze
+  AUSBILDUNGS_TYPEN = {
+    1 => '<keine>',
+    2 => 'Primarschule',
+    3 => 'Sekundarschule',
+    4 => 'Fachmittelschule',
+    5 => 'Fahhochschule',
+    6 => 'Gymnasium',
+    7 => 'GEP-Einsatz',
+    8 => 'EBA Eidg. Berufsattest',
+    9 => 'eidg. Anerkannte Berufslehre'
+  }.freeze
 
-  JOURNAL_KATEGORIEN = [
-    nil,
-    'Telefonat',
-    'Gespräch',
-    'E-Mail',
-    'Rückmeldung',
-    'Datei'
-  ].freeze
+  JOURNAL_KATEGORIEN = {
+    1 => 'Telefonat',
+    2 => 'Gespräch',
+    3 => 'E-Mail',
+    4 => 'Rückmeldung',
+    5 => 'Datei'
+  }.freeze
 end

--- a/lib/access_import/accessors/accessor.rb
+++ b/lib/access_import/accessors/accessor.rb
@@ -5,12 +5,12 @@ class Accessor
   attr_reader :records
 
   def initialize(acdb, *other_accessors)
-    add_other_accessors(other_accessors) if other_accessors.any?
+    add_other_accessors(*other_accessors) if other_accessors.any?
     @acdb = acdb
     @records = hash_all
   end
 
-  def add_other_accessors(accessors)
+  def add_other_accessors(*accessors)
     accessors.each do |accessor|
       instance_variable_set("@#{accessor.class.name.underscore}", accessor)
     end

--- a/lib/access_import/accessors/accessor.rb
+++ b/lib/access_import/accessors/accessor.rb
@@ -2,12 +2,10 @@ require 'access_import/acc_utils'
 
 class Accessor
   include AccUtils
-  attr_reader :records
 
   def initialize(acdb, *other_accessors)
     add_other_accessors(*other_accessors) if other_accessors.any?
     @acdb = acdb
-    @records = hash_all
   end
 
   def add_other_accessors(*accessors)
@@ -17,11 +15,11 @@ class Accessor
   end
 
   def all
-    @records
+    @all ||= hash_all
   end
 
   def find(id)
-    @records[id.to_i]
+    all[id.to_i]
   end
 
   SEMESTER = [

--- a/lib/access_import/accessors/ausbildungen.rb
+++ b/lib/access_import/accessors/ausbildungen.rb
@@ -11,7 +11,7 @@ class Ausbildungen < Accessor
   end
 
   def where_haupt_person(hauptperson_id)
-    @records.select do |_k, ausbildung|
+    all.select do |_key, ausbildung|
       ausbildung[:fk_Hauptperson] == hauptperson_id.to_i
     end
   end

--- a/lib/access_import/accessors/begleitete.rb
+++ b/lib/access_import/accessors/begleitete.rb
@@ -11,9 +11,9 @@ class Begleitete < Accessor
     rec
   end
 
-  def where_personen_rolle(pr_id)
-    @records.select do |_key, pr|
-      pr[:fk_PersonenRolle] == pr_id.to_i
+  def where_personen_rolle(personen_rolle_id)
+    all.select do |_key, personen_rolle|
+      personen_rolle[:fk_PersonenRolle] == personen_rolle_id.to_i
     end
   end
 

--- a/lib/access_import/accessors/einsatz_orte.rb
+++ b/lib/access_import/accessors/einsatz_orte.rb
@@ -12,7 +12,7 @@ class EinsatzOrte < Accessor
   end
 
   def where_haupt_person(hauptperson_id)
-    @records.select do |_k, ausbildung|
+    all.select do |_key, ausbildung|
       ausbildung[:fk_Hauptperson] == hauptperson_id.to_i
     end
   end

--- a/lib/access_import/accessors/fallstellen.rb
+++ b/lib/access_import/accessors/fallstellen.rb
@@ -1,4 +1,4 @@
-class Fallstellen
+class Fallstellen < Accessor
   def hash_all
     make_mappable(:tbl_FallStellen, :pk_FallStelle, true)
   end

--- a/lib/access_import/accessors/freiwilligen_einsaetze.rb
+++ b/lib/access_import/accessors/freiwilligen_einsaetze.rb
@@ -17,21 +17,21 @@ class FreiwilligenEinsaetze < Accessor
     )
   end
 
-  def where_begleitete(beg_id)
-    @records.select do |_k, fw_einsatz|
-      fw_einsatz[:fk_Begleitete] == beg_id.to_i
+  def where_begleitete(begleitet_id)
+    all.select do |_key, fw_einsatz|
+      fw_einsatz[:fk_Begleitete] == begleitet_id.to_i
     end
   end
 
   def where_einsatz_ort(einsatz_ort_id)
-    @records.select do |_k, fw_einsatz|
+    all.select do |_key, fw_einsatz|
       fw_einsatz[:fk_EinsatzOrt] == einsatz_ort_id.to_i
     end
   end
 
-  def where_personen_rolle(pr_id)
-    @records.select do |_k, fw_einsatz|
-      fw_einsatz[:fk_PersonenRolle] == pr_id.to_i
+  def where_personen_rolle(personen_rolle_id)
+    all.select do |_key, fw_einsatz|
+      fw_einsatz[:fk_PersonenRolle] == personen_rolle_id.to_i
     end
   end
 end

--- a/lib/access_import/accessors/freiwilligen_entschaedigung.rb
+++ b/lib/access_import/accessors/freiwilligen_entschaedigung.rb
@@ -14,7 +14,7 @@ class FreiwilligenEntschaedigung < Accessor
   end
 
   def where_personen_rolle(pr_id)
-    @records.select do |_k, fw_einsatz|
+    all.select do |_key, fw_einsatz|
       fw_einsatz[:fk_PersonenRolle] == pr_id.to_i
     end
   end

--- a/lib/access_import/accessors/journale.rb
+++ b/lib/access_import/accessors/journale.rb
@@ -11,7 +11,7 @@ class Journale < Accessor
   end
 
   def where_haupt_person(hp_id)
-    @records.select do |_k, journal|
+    all.select do |_key, journal|
       journal[:fk_Hauptperson] == hp_id.to_i
     end
   end

--- a/lib/access_import/accessors/kontoangaben.rb
+++ b/lib/access_import/accessors/kontoangaben.rb
@@ -10,7 +10,7 @@ class Kontoangaben < Accessor
   end
 
   def where_haupt_person(hp_id)
-    @records.select do |_k, kontoangabe|
+    all.select do |_key, kontoangabe|
       kontoangabe[:fk_Hauptperson] == hp_id.to_i
     end
   end

--- a/lib/access_import/accessors/laender.rb
+++ b/lib/access_import/accessors/laender.rb
@@ -60,10 +60,10 @@ class Laender < Accessor
   end
 
   def alpha_2_search(kurzform)
-    ISO3166::Country.all.select { |c| c.alpha2 == kurzform.upcase } || []
+    ISO3166::Country.all.select { |country| country.alpha2 == kurzform.upcase }
   end
 
   def alpha_3_search(kurzform)
-    ISO3166::Country.all.select { |c| c.alpha3 == kurzform.upcase } || []
+    ISO3166::Country.all.select { |country| country.alpha3 == kurzform.upcase }
   end
 end

--- a/lib/access_import/accessors/personen_rolle.rb
+++ b/lib/access_import/accessors/personen_rolle.rb
@@ -21,26 +21,26 @@ class PersonenRolle < Accessor
   end
 
   def all_volunteers
-    @records.select do |_id, val|
-      val[:z_Rolle] == 1
+    all.select do |_id, personen_rolle|
+      personen_rolle[:z_Rolle] == ACCESS_ROLES.volunteer
     end
   end
 
   def all_clients
-    @records.select do |_id, val|
-      val[:z_Rolle] == 2
+    all.select do |_id, personen_rolle|
+      personen_rolle[:z_Rolle] == ACCESS_ROLES.client
     end
   end
 
   def all_animators
-    @records.select do |_id, val|
-      val[:z_Rolle] == 3
+    all.select do |_id, personen_rolle|
+      personen_rolle[:z_Rolle] == ACCESS_ROLES.animator
     end
   end
 
   def all_participants
-    @records.select do |_id, val|
-      val[:z_Rolle] == 4
+    all.select do |_id, personen_rolle|
+      personen_rolle[:z_Rolle] == ACCESS_ROLES.participant
     end
   end
 end

--- a/lib/access_import/accessors/personen_rolle.rb
+++ b/lib/access_import/accessors/personen_rolle.rb
@@ -1,3 +1,5 @@
+require 'ostruct'
+
 class PersonenRolle < Accessor
   def hash_all
     make_mappable(:tbl_Personenrollen, :pk_PersonenRolle, true)
@@ -8,17 +10,18 @@ class PersonenRolle < Accessor
     rec = parse_int_fields(rec, :b_EinführungsKurs, :b_Interesse, :b_SpesenVerzicht,
       :fk_Hauptperson, :fk_Kostenträger, :pk_PersonenRolle, :z_AnzErw, :z_AnzKind,
       :z_Familienverband, :z_Rolle)
-    rec[:rolle] = map_rolle(rec[:z_Rolle])
+    rec[:rolle] = ACCESS_TO_OWN_ROLES_MAP[rec[:z_Rolle]]
     rec
   end
 
-  def map_rolle(z_rolle)
-    return 'Volunteer' if z_rolle == 1
-    return 'Client' if z_rolle == 2
-    return 'Animator' if z_rolle == 3
-    return 'Participant' if z_rolle == 4
-    nil
-  end
+  ACCESS_TO_OWN_ROLES_MAP = {
+    1 => 'Volunteer',
+    2 => 'Client',
+    3 => 'Animator',
+    4 => 'Participant'
+  }.freeze
+
+  ACCESS_ROLES = OpenStruct.new(volunteer: 1, client: 2, animator: 3, participant: 4).freeze
 
   def all_volunteers
     all.select do |_id, personen_rolle|

--- a/lib/access_import/accessors/sprache_pro_hauptperson.rb
+++ b/lib/access_import/accessors/sprache_pro_hauptperson.rb
@@ -16,8 +16,8 @@ class SpracheProHauptperson < Accessor
   end
 
   def add_kentniss_levels(record)
-    kentnisse = record.slice(*level_keys).compact.map do |k, v|
-      [k.to_s[3..-1].to_sym, LANGUAGE_LEVELS[v]]
+    kentnisse = record.slice(*level_keys).compact.map do |key, level|
+      [key.to_s[3..-1].to_sym, LANGUAGE_LEVELS[level]]
     end.to_h
     record.merge(kentnisse).except(*level_keys)
   end
@@ -31,9 +31,9 @@ class SpracheProHauptperson < Accessor
   end
 
   def where_person(person_id)
-    languages = @records.select do |key|
-      key.to_s == person_id.to_s
+    persons_sprachen = all.select do |_key, sprache_hauptperson|
+      sprache_hauptperson[:fk_Hauptperson].to_s == person_id.to_s
     end
-    languages.map { |s| down_hkeys(s[1]) }
+    persons_sprachen.map { |_key, sprache_hauptperson| down_hkeys(sprache_hauptperson) }
   end
 end

--- a/lib/access_import/accessors/sprache_pro_hauptperson.rb
+++ b/lib/access_import/accessors/sprache_pro_hauptperson.rb
@@ -3,7 +3,12 @@ class SpracheProHauptperson < Accessor
     make_mappable(:tbl_SpracheProHauptperson, :pk_SpracheProPerson, true)
   end
 
-  LANGUAGE_LEVELS = [nil, 'basic', 'good', 'fluent', 'native_speaker', nil].freeze
+  LANGUAGE_LEVELS = {
+    1 => 'basic',
+    2 => 'good',
+    3 => 'fluent',
+    7 => 'native_speaker'
+  }.freeze
 
   def sanitize_record(rec)
     rec = parse_int_fields(rec, *level_keys, :fk_Hauptperson, :fk_Sprache, :pk_SpracheProPerson)

--- a/lib/access_import/accessors/sprache_pro_hauptperson.rb
+++ b/lib/access_import/accessors/sprache_pro_hauptperson.rb
@@ -26,10 +26,6 @@ class SpracheProHauptperson < Accessor
     ['Le', 'Sc', 'Sp', 'Ve'].map { |k| "fk_Kenntnisstufe#{k}".to_sym }
   end
 
-  def all
-    @records
-  end
-
   def where_person(person_id)
     persons_sprachen = all.select do |_key, sprache_hauptperson|
       sprache_hauptperson[:fk_Hauptperson].to_s == person_id.to_s

--- a/lib/access_import/accessors/sprache_pro_hauptperson.rb
+++ b/lib/access_import/accessors/sprache_pro_hauptperson.rb
@@ -23,7 +23,7 @@ class SpracheProHauptperson < Accessor
   end
 
   def level_keys
-    ['Le', 'Sc', 'Sp', 'Ve'].map { |k| "fk_Kenntnisstufe#{k}".to_sym }
+    ['Le', 'Sc', 'Sp', 'Ve'].map { |key| "fk_Kenntnisstufe#{key}".to_sym }
   end
 
   def where_person(person_id)

--- a/lib/access_import/accessors/sprachen.rb
+++ b/lib/access_import/accessors/sprachen.rb
@@ -13,6 +13,6 @@ class Sprachen < Accessor
 
   def language(sprache)
     sprache = 'Tigrinja' if sprache == 'Tigrinia'
-    I18nData.languages(:de).select { |_k, v| v == sprache }.keys.first
+    I18nData.languages(:de).select { |_key, language| language == sprache }.keys.first
   end
 end

--- a/lib/access_import/accessors/stundenerfassung.rb
+++ b/lib/access_import/accessors/stundenerfassung.rb
@@ -11,7 +11,7 @@ class Stundenerfassung < Accessor
   end
 
   def where_personen_rolle(pr_id)
-    @records.select do |_k, stunden_erfassung|
+    all.select do |_key, stunden_erfassung|
       stunden_erfassung[:fk_PersonenRolle] == pr_id.to_i
     end
   end

--- a/lib/access_import/client_transform.rb
+++ b/lib/access_import/client_transform.rb
@@ -22,8 +22,10 @@ class ClientTransform
       language_skills_attributes: language_skills_attributes(haupt_person[:sprachen]),
       contact_attributes: contact_attributes(haupt_person),
       relatives_attributes: relatives_attrs(relatives),
-      import_attributes: access_import(personen_rolle, :pk_PersonenRolle, haupt_person,
-        familien_rolle)
+      import_attributes: access_import(
+        :tbl_PersonenRollen, personen_rolle[:pk_PersonenRolle], personen_rolle: personen_rolle,
+        haupt_person: haupt_person, familien_rolle: familien_rolle
+      )
     }
   end
 

--- a/lib/access_import/volunteer_transform.rb
+++ b/lib/access_import/volunteer_transform.rb
@@ -26,7 +26,10 @@ class VolunteerTransform
       nationality: haupt_person[:nationality],
       language_skills_attributes: language_skills_attributes(haupt_person[:sprachen]),
       contact_attributes: contact_attributes(haupt_person),
-      import_attributes: access_import(personen_rolle, :pk_PersonenRolle, haupt_person)
+      import_attributes: access_import(
+        :tbl_Personenrollen, personen_rolle[:pk_PersonenRolle], personen_rolle: personen_rolle,
+        haupt_person: haupt_person
+      )
     }
   end
 end


### PR DESCRIPTION
# [Story in Trello](https://trello.com/c/f3bB3jDu/102-import-client-volunteer-use-access-creation-time-and-updated-time-for-createdat-and-updatedat)

* Languages where not imported correct
  * foreign key mixup caused wrong language to be joined
  * levels where mapped wrong
* creation time and update time are taken from the access db and used on the imported client and volunteer records.
  * this allows to have usable sorting and more. I recon it would simply be terrible without
* Records that have a RollenEnde date present get RESIGNED (Volunteer) or FINISHED (Client) state
* Volunteers have a first_language collumn, that just displayed the first language in the list so far. That cannot be the propper implementation, because if there is multiple language_skills for a record, the chances are 50/50 at best, that this really is the natively spoken first language 😉 

## Done?

### Done for approval?

* [ ] Code quality checks are green
* [x] Translated
* [x] Code is reviewed

### Done after the merge?

* [ ] Deployed to staging after the merge
* [ ] Tested manually on staging
