### PR TITLE
fix/client mail update

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -9,7 +9,7 @@ class Contact < ApplicationRecord
 
   validates :street, :postal_code, :city, presence: true, if: :needs_address?
 
-  after_save :update_user_email
+  after_save :update_user_email, unless: :client?
 
   def to_s
     last_name

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -95,4 +95,15 @@ class UserTest < ActiveSupport::TestCase
     @user.reload
     assert_equal 'supervolunteer@example.com', @user.email
   end
+
+  test 'updating client mail doesnt change current user email' do
+    @superadmin = create :user, role: 'superadmin', email: 'superadmin@example.com'
+    @client = create :user, email: 'client@example.com'
+    login_as(@superadmin)
+    @client.profile.contact.update(primary_email: 'superclient@example.com')
+    @client.reload
+    assert_equal 'superclient@example.com', @client.profile.contact.primary_email
+    assert_not_equal 'superclient@example.com', @superadmin.email
+    assert_equal 'superadmin@example.com', @superadmin.email
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -97,13 +97,12 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'updating client mail doesnt change current user email' do
-    @superadmin = create :user, role: 'superadmin', email: 'superadmin@example.com'
-    @client = create :user, email: 'client@example.com'
-    login_as(@superadmin)
-    @client.profile.contact.update(primary_email: 'superclient@example.com')
+    @client = create :client
+    @client.contact.update(primary_email: 'superclient@example.com')
     @client.reload
-    assert_equal 'superclient@example.com', @client.profile.contact.primary_email
-    assert_not_equal 'superclient@example.com', @superadmin.email
-    assert_equal 'superadmin@example.com', @superadmin.email
+    @client.user.reload
+
+    assert_equal 'superclient@example.com', @client.contact.primary_email
+    assert_not_equal 'superclient@example.com', @client.user.email
   end
 end

--- a/test/system/index_action_partials_test.rb
+++ b/test/system/index_action_partials_test.rb
@@ -22,7 +22,7 @@ class IndexActionPartialsTest < ApplicationSystemTestCase
     click_link 'Print'
     assert_equal page.windows.count, 2
     page.switch_to_window(page.windows[1])
-    assert page.has_link? @client.contact.primary_email
+    assert page.has_text? @client.contact.primary_email
   end
 
   test 'volunteer list shows all actions needed' do


### PR DESCRIPTION
# [Story in Trello](https://trello.com/c/3GJLklmX/44-bug-if-i-register-a-client-the-currentuser-mail-gets-overwritten)

ensuring that if a client mail is updated, the method `update_user_email` is not used, because a client is not a user.

## Done?

### Done for approval?

* [x] Code quality checks are green
* [x] Story under test
* [x] Code is reviewed

### Done after the merge?

* [ ] Deployed to staging after the merge
* [ ] Tested manually on staging
