### PR TITLE
fix: Remove back button if volunteer is logged in

### DIFF
--- a/app/views/volunteers/show.html.slim
+++ b/app/views/volunteers/show.html.slim
@@ -27,7 +27,7 @@ nav.navbar.section-navigation
       li = button_link t('.report_hours'), new_volunteer_hour_url(@volunteer)
       li = button_link t('.hour_reports'), volunteer_hours_path(@volunteer)
     li= button_link current_user.volunteer? ? t('edit_profile') : t_title(:edit), edit_volunteer_path(@volunteer)
-    li= form_navigation_btn :back, with_row: false
+    li= form_navigation_btn :back, with_row: false unless current_user.volunteer?
 
 - if policy(Volunteer).can_manage?
   h3= t('checklist')


### PR DESCRIPTION
# [Story in Trello](https://trello.com/c/0X08TCa7/57-fixes-back-leads-to-not-authorized-logged-in-as-volunteer)

## Done?

### Done for approval?

* [x] Acceptance criteria are met
* [x] Code quality checks are green
* ~[ ] Readme updated if needed~
* ~[ ] Story under test~
* ~[ ] Mobile works~
* ~[ ] Seeds created~
* ~[ ] Translated~
* [ ] Code is reviewed

### Done after the merge?

* [ ] Deployed to staging after the merge
* [ ] Tested manually on staging
