### PR TITLE
BugFix: Group assignment agreement crashes when group assignment gets destroyed

### DIFF
--- a/app/views/group_assignments/_volunteer_group_assignments.html.slim
+++ b/app/views/group_assignments/_volunteer_group_assignments.html.slim
@@ -29,8 +29,8 @@ table.table.table-striped.group-assignments-table
         td= l(group_assignment.period_end) if group_assignment.period_end
         - if group_assignment.group_offer
           td= link_to t_action(:show), group_offer_path(group_assignment.group_offer)
-          td= link_to t('download'), group_assignment_path(group_assignment, format: :pdf)
         - if editable
+          td= link_to t('download'), group_assignment_path(group_assignment, format: :pdf)
           - if policy(GroupOffer).edit?
             td= link_to t_action(:edit), edit_group_offer_path(group_assignment.group_offer)
           - if policy(GroupOffer).destroy?

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -151,6 +151,7 @@ de:
       rejected: Abgelehnt
       reserved: Reserviert
       resigned: Abgemeldet
+      undecided: Nicht entschieden
     updated_at: Geändert um
     volunteer_applications: &id-volunteers-by-actions
       feedback:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -150,6 +150,7 @@ en:
       rejected: Rejected
       reserved: Reserved
       resigned: Terminated
+      undecided: Undecided
     volunteer_applications: &id-volunteers-by-actions
       feedback: &id-volunteer-feedbacks
         new: New feedback

--- a/test/system/group_offers_test.rb
+++ b/test/system/group_offers_test.rb
@@ -87,7 +87,7 @@ class GroupOffersTest < ApplicationSystemTestCase
     refute page.has_text? group_offer.title
   end
 
-  test 'deleting volunteer from group offer creates log entry' do
+  test 'deleting volunteer from group offer creates log entry without an agreement' do
     login_as create(:user)
     volunteer = create :volunteer
     group_offer = create :group_offer, volunteers: [volunteer]
@@ -105,6 +105,7 @@ class GroupOffersTest < ApplicationSystemTestCase
     refute page.has_text? 'Active group offers'
     assert page.has_text? 'Group offers log'
     assert page.has_link? group_offer.title
+    refute page.has_link? 'Download'
   end
 
   test 'modifying volunteer dates creates log entry' do


### PR DESCRIPTION
# [Story in Trello](https://trello.com/c/GSoRlcgm/91-bugfix-group-assignment-agreement-crashes-when-group-assignment-gets-destroyed)

## Done?

### Done for approval?

* [x] Acceptance criteria are met
* [x] Code quality checks are green
* ~[ ] Readme updated if needed~
* ~[ ] Story under test~
* ~[ ] Mobile works~
* ~[ ] Seeds created~
* ~[ ] Translated~
* [x] Code is reviewed

### Done after the merge?

* [ ] Deployed to staging after the merge
* [ ] Tested manually on staging
