### PR TITLE
default group offer categories as migration, so they dont need to be …

### DIFF
--- a/db/migrate/20171025125818_add_default_group_offer_categories.rb
+++ b/db/migrate/20171025125818_add_default_group_offer_categories.rb
@@ -1,0 +1,11 @@
+class AddDefaultGroupOfferCategories < ActiveRecord::Migration[5.1]
+  def change
+    [
+      'Sport', 'Kreativ', 'Musik', 'Kultur', 'Bildung', 'Deutsch-Kurs',
+      'Schreibdienst für Wohnungssuchende', 'Hausaufgabenhilfe', 'Bewerbungswerkstatt', 'Freizeit',
+      'Kinderbetreuung', 'Fussballnachmittag', 'Nähen'
+    ].each do |category_name|
+      GroupOfferCategory.find_or_create_by(category_name: category_name)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171011151358) do
+ActiveRecord::Schema.define(version: 20171025125818) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -70,7 +70,6 @@ ActiveRecord::Schema.define(version: 20171011151358) do
     t.datetime "deleted_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "group_offer", default: false
     t.index ["deleted_at"], name: "index_certificates_on_deleted_at"
     t.index ["user_id"], name: "index_certificates_on_user_id"
     t.index ["volunteer_id"], name: "index_certificates_on_volunteer_id"


### PR DESCRIPTION
…added manually or by seed

# [Story in Trello](https://trello.com/c/3lPd67wL/93-add-default-groupoffercategories-by-migration)
