### PR TITLE
fix link to reminder.assignment.feedback link wrong

### DIFF
--- a/app/views/reminders/index.html.slim
+++ b/app/views/reminders/index.html.slim
@@ -25,8 +25,7 @@ h1= t('application.navigation.reminders')
                 volunteer_hour_url(reminder.volunteer, reminder.assignment.last_hour)
           td
             - if reminder.assignment.last_feedback
-              = link_to l(reminder.assignment.last_feedback.updated_at.to_date),
-                assignment_feedback_url(reminder.assignment, reminder.assignment.last_feedback)
+              = link_to l(reminder.assignment.last_feedback.updated_at.to_date), polymorphic_path([reminder.volunteer, reminder.assignment, reminder.assignment.last_feedback])
           - if reminder.sent_at
             td= l(reminder.sent_at)
           - else


### PR DESCRIPTION
# [Story in Trello](https://trello.com/c/Oc6Z6hxF/105-bug-wrong-link-to-assignment-feedback-in-reminders-index-view)

## Done?

### Done for approval?

* [ ] Acceptance criteria are met
* [ ] Code quality checks are green
* [ ] Readme updated if needed
* [ ] Story under test
* [ ] Mobile works
* [ ] Seeds created
* [ ] Translated
* [ ] Code is reviewed

### Done after the merge?

* [ ] Deployed to staging after the merge
* [ ] Tested manually on staging
