### PR TITLE
BugFix: Billing Expenses & Certificate create depends also on Group Assignments

### DIFF
--- a/app/views/volunteers/show.html.slim
+++ b/app/views/volunteers/show.html.slim
@@ -7,7 +7,7 @@ nav.navbar.section-navigation
       ul.list-inline
         - if @volunteer.seeking_clients?
           li= button_link t_title(:new, Assignment), new_assignment_path(volunteer_id: @volunteer)
-        - if @volunteer.assignments.any?
+        - if @volunteer.internal_and_started_assignments?
           li
             = simple_form_for [@volunteer, BillingExpense.new] do |f|
               = f.hidden_field :volunteer_id, value: @volunteer.id

--- a/app/views/volunteers/show.html.slim
+++ b/app/views/volunteers/show.html.slim
@@ -14,7 +14,7 @@ nav.navbar.section-navigation
               = f.button :submit
           - if @volunteer.billing_expenses.any?
             li= button_link t_title(:index, BillingExpense), volunteer_billing_expenses_path(@volunteer)
-        - if @volunteer.assignments?
+        - if @volunteer.internal_and_started_assignments?
           li= button_link t('.new_certificate'), new_volunteer_certificate_path(@volunteer)
           - if @volunteer.certificates.size == 1
             li= button_link t('.show_certificate'), volunteer_certificate_path(@volunteer, @volunteer.certificates.first)

--- a/test/system/billing_expenses_test.rb
+++ b/test/system/billing_expenses_test.rb
@@ -52,4 +52,15 @@ class BillingExpensesTest < ApplicationSystemTestCase
     assert page.has_text? 'PLZ / Ort'
     assert page.has_text? 'Bank / IBAN'
   end
+
+  test 'volunteer that has only group offers can create billing expenses' do
+    volunteer = create :volunteer
+    group_offer = create :group_offer, volunteers: [volunteer]
+    volunteer.group_assignments.last.update(period_start: 2.months.ago)
+    create :hour, hourable: group_offer, volunteer: volunteer, hours: '3', minutes: '30'
+
+    visit volunteer_path(volunteer)
+    click_button 'Create Billing expense'
+    assert page.has_text? 'Billing expense was successfully created.'
+  end
 end

--- a/test/system/certificates_test.rb
+++ b/test/system/certificates_test.rb
@@ -57,4 +57,17 @@ class CertificatesTest < ApplicationSystemTestCase
     assert page.has_text? 'The Testology Institute'
     assert page.has_text? 'Bold or not bold, that is this tests Question? both'
   end
+
+  test 'volunteer that has only group offers can have certificate' do
+    volunteer = create :volunteer
+    create :group_offer, volunteers: [volunteer]
+    volunteer.group_assignments.last.update(period_start: 2.months.ago)
+    login_as @user
+
+    visit volunteer_path(volunteer)
+    assert page.has_link? 'Create certificate'
+    click_link 'Create certificate'
+    page.find_button('Create Certificate').trigger('click')
+    assert page.has_text? 'Die AOZ ist ein Unternehmen der Stadt Zürich'
+  end
 end


### PR DESCRIPTION
# [Story in Trello](https://trello.com/c/kvWr2gsw/104-bug-add-billing-expenses-certification-depends-only-on-assignments)

## Done?

### Done for approval?

* [x] Acceptance criteria are met
* [x] Code quality checks are green
* ~[ ] Readme updated if needed~
* [x] Story under test
* ~[ ] Mobile works~
* ~[ ] Seeds created~
* ~[ ] Translated~
* [x] Code is reviewed

### Done after the merge?

* [ ] Deployed to staging after the merge
* [ ] Tested manually on staging
