### PR TITLE
Fixes: restrict back button department edit

### DIFF
--- a/app/views/departments/edit.html.slim
+++ b/app/views/departments/edit.html.slim
@@ -4,4 +4,5 @@
 
 = render 'form'
 
-= form_navigation_btn :back
+- if policy(Department).index?
+  = form_navigation_btn :back


### PR DESCRIPTION
# [Story in Trello](https://trello.com/c/jOFRgK5S/27-bug-the-department-manager-ui-at-the-department-edit-page-should-not-have-back-button)

## Done?

### Done for approval?

* [x] Acceptance criteria are met
* [x] Code quality checks are green
* ~[ ] Readme updated if needed~
* ~[ ] Story under test~
* ~[ ] Mobile works~
* ~[ ] Seeds created~
* ~[ ] Translated~
* [x] Code is reviewed

### Done after the merge?

* [ ] Deployed to staging after the merge
* [ ] Tested manually on staging
