### PR TITLE
Fix: restrict edit group offer link on volunteer show

### DIFF
--- a/app/views/group_assignments/_volunteer_group_assignments.html.slim
+++ b/app/views/group_assignments/_volunteer_group_assignments.html.slim
@@ -24,7 +24,8 @@ table.table.table-striped.group-assignments-table
           td= link_to t_action(:show), group_offer_path(group_assignment.group_offer)
         - if editable
           td= link_to t('download'), group_assignment_path(group_assignment, format: :pdf)
-          td= link_to t_action(:edit), edit_group_offer_path(group_assignment.group_offer)
+          - if policy(group_assignment.group_offer).edit?
+            td= link_to t_action(:edit), edit_group_offer_path(group_assignment.group_offer)
           - if policy(GroupOffer).destroy?
             td= link_to t_action(:destroy), group_offer_path(group_assignment.group_offer), confirm_deleting(group_assignment.group_offer)
           - else


### PR DESCRIPTION
# [Story in Trello](https://trello.com/c/fvuKDWfG/20-bug-remove-edit-group-offer-button-on-volunteer-ui)

## Done?

### Done for approval?

* [x] Acceptance criteria are met
* [x] Code quality checks are green
* ~[ ] Readme updated if needed~
* ~[ ] Story under test~
* ~[ ] Mobile works~
* ~[ ] Seeds created~
* ~[ ] Translated~
* [x] Code is reviewed

### Done after the merge?

* [ ] Deployed to staging after the merge
* [ ] Tested manually on staging
