### PR TITLE
Fix: volunteer destroy doesnt destroy group offer show

### DIFF
--- a/app/views/group_offers/show.html.slim
+++ b/app/views/group_offers/show.html.slim
@@ -80,15 +80,16 @@ h1= @group_offer.title
           th= t_attr(:period_end, GroupAssignment)
       tbody
         - @group_offer.group_assignments.each do |group_assignment|
-          tr
-            td
-              - if policy(Volunteer).show?
-                = link_to group_assignment.volunteer, volunteer_path(group_assignment.volunteer)
-              - else
-                = group_assignment.volunteer
-            td= group_assignment.responsible ? t_attr(:responsible, GroupAssignment) : t_attr(:member, GroupAssignment)
-            td= l(group_assignment.period_start) if group_assignment.period_start
-            td= l(group_assignment.period_end) if group_assignment.period_end
+          - if group_assignment.volunteer
+            tr
+              td
+                - if policy(Volunteer).show?
+                  = link_to group_assignment.volunteer, volunteer_path(group_assignment.volunteer)
+                - else
+                  = group_assignment.volunteer
+              td= group_assignment.responsible ? t_attr(:responsible, GroupAssignment) : t_attr(:member, GroupAssignment)
+              td= l(group_assignment.period_start) if group_assignment.period_start
+              td= l(group_assignment.period_end) if group_assignment.period_end
 
 - unless params[:format] == 'pdf'
   = form_navigation_btn :edit

--- a/test/system/group_offers_test.rb
+++ b/test/system/group_offers_test.rb
@@ -151,4 +151,21 @@ class GroupOffersTest < ApplicationSystemTestCase
     assert page.has_text? 'Group offers log'
     assert page.has_text? title
   end
+
+  test 'deleting volunteer does not crash group offer show' do
+    login_as create(:user)
+    volunteer1 = create :volunteer
+    volunteer2 = create :volunteer
+    group_offer = create :group_offer, volunteers: [volunteer1, volunteer2]
+
+    visit group_offer_path(group_offer)
+    assert page.has_link? volunteer1.contact.full_name
+    assert page.has_link? volunteer2.contact.full_name
+
+    Volunteer.find(volunteer1.id).destroy
+
+    visit group_offer_path(group_offer)
+    refute page.has_link? volunteer1.contact.full_name
+    assert page.has_link? volunteer2.contact.full_name
+  end
 end


### PR DESCRIPTION
# [Story in Trello](https://trello.com/c/8AtRSata/26-bug-if-a-volunteer-has-a-group-offer-and-then-gets-deleted-group-offer-can-no-longer-be-shown-downloaded)

## Done?

### Done for approval?

* [x] Acceptance criteria are met
* [x] Code quality checks are green
* ~[ ] Readme updated if needed~
* [x] Story under test
* ~[ ] Mobile works~
* ~[ ] Seeds created~
* ~[ ] Translated~
* [x] Code is reviewed

### Done after the merge?

* [ ] Deployed to staging after the merge
* [ ] Tested manually on staging
