### PR TITLE
BugFix: Accepted on creation volunteers get invited

### DIFF
--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -30,7 +30,13 @@ class VolunteersController < ApplicationController
     @volunteer.registrar = current_user
     authorize @volunteer
     if @volunteer.save
-      redirect_to @volunteer, notice: t('volunteer_created')
+      if @volunteer.acceptance == 'accepted'
+        invite_volunteer_user
+        redirect_to @volunteer, notice: t('volunteer_created_invite_sent',
+          email: @volunteer.primary_email)
+      else
+        redirect_to @volunteer, notice: t('volunteer_created')
+      end
     else
       render :new
     end

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -900,6 +900,7 @@ de:
   voluntary_platform: Freiwilligen Plattform
   volunteer_application: Freiwilligen Anmeldung
   volunteer_created: Freiwillige/r wurde erfolgreich erstellt.
+  volunteer_created_invite_sent: 'Freiwillige/r wurde erfolgreich erstellt. Einladung wurde an %{email} verschickt.'
   volunteer_destroyed: Freiwillige/r wurde erfolgreich gelöscht.
   volunteer_emails:
     one: Bestätigungs-Mail

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -721,6 +721,7 @@ en:
   volunteer_application: Volunteer Registration
   volunteer_availability: What times are you available for voluntary engagement?
   volunteer_created: Volunteer was successfully created.
+  volunteer_created_invite_sent: 'Volunteer was successfully created. Invitation sent to %{email}.'
   volunteer_destroyed: Volunteer was successfully deleted.
   volunteer_emails:
     one: Volunteer email


### PR DESCRIPTION
# [Story in Trello](https://trello.com/c/3e2X4UjJ/2-bug-creating-a-volunteer-sends-registration-mail-out-only-if-first-selection-is-not-decided-and-then-updated-on-accepted)

## Done?

### Done for approval?

* [x] Acceptance criteria are met
* [x] Code quality checks are green
* ~[ ] Readme updated if needed~
* [x] Story under test
* ~[ ] Mobile works~
* ~[ ] Seeds created~
* [x] Translated
* [x] Code is reviewed

### Done after the merge?

* [ ] Deployed to staging after the merge
* [ ] Tested manually on staging
