### PR TITLE
Changes: superadmin can edit only their password

### DIFF
--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -3,7 +3,7 @@
   .row
     .col-xs-12
       = f.input :email
-      - if action_name == 'edit'
+      - if action_name == 'edit' && user == current_user
         = f.input :password
 
       - if policy(User).create?

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -93,4 +93,20 @@ class UsersTest < ApplicationSystemTestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal volunteer.contact.primary_email, email['to'].to_s
   end
+
+  test 'superadmin can edit only their password' do
+    other_superadmin = create :user
+    department_manager = create :department_manager
+    social_worker = create :social_worker
+    volunteer = create :user_volunteer
+    other_users = [other_superadmin, department_manager, social_worker, volunteer]
+
+    other_users.each do |user|
+      visit edit_user_path(user)
+      refute page.has_field? 'Password'
+    end
+
+    visit edit_user_path(@user)
+    assert page.has_field? 'Password'
+  end
 end


### PR DESCRIPTION
# [Story in Trello](https://trello.com/c/k9nhezUu/25-ein-superadmin-sollte-nicht-das-passwort-von-anderen-usern-%C3%A4ndern-k%C3%B6nnen)

## Done?

### Done for approval?

* [x] Acceptance criteria are met
* [x] Code quality checks are green
* ~[ ] Readme updated if needed~
* [x] Story under test
* ~[ ] Mobile works~
* ~[ ] Seeds created~
* ~[ ] Translated~
* [x] Code is reviewed

### Done after the merge?

* [ ] Deployed to staging after the merge
* [ ] Tested manually on staging
