### PR TITLE
WIP: Find why travis fails on delete journal through edit & restore the test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,12 @@ cache:
   bundler: true
   directories:
     - .phantomjs
+    - .rvm
 
 services: postgresql
 
 addons:
   postgresql: "9.4"
-
-bundler_args: --without production --without development
 
 before_script:
   - bundle exec rails db:create

--- a/test/system/journals_test.rb
+++ b/test/system/journals_test.rb
@@ -33,21 +33,19 @@ class JournalsTest < ApplicationSystemTestCase
     assert page.has_text? 'My bogus demo text body, just for this test.'
   end
 
-  # Test runs locally, but misteriously never runs on travis
-  #
-  # test 'can_delete_a_journal_through_edit' do
-  #   Journal.with_deleted.map(&:really_destroy!)
-  #   create :journal, journalable: @volunteer
-  #   visit volunteer_path(@volunteer)
+  test 'can_delete_a_journal_through_edit' do
+    Journal.with_deleted.map(&:really_destroy!)
+    create :journal, journalable: @volunteer
+    visit volunteer_path(@volunteer)
 
-  #   click_button 'Journal'
-  #   within '#journalBlock' do
-  #     click_link 'Edit'
-  #   end
-  #   page.find('a', text: 'Delete').click
-  #   assert page.has_text? 'Journal was successfully deleted.'
-  #   click_button 'Journal'
-  #   refute page.has_link? @journal_volunteer.user.full_name
-  #   refute page.has_text? @journal_volunteer.body
-  # end
+    click_button 'Journal'
+    within '#journalBlock' do
+      click_link 'Edit'
+    end
+    page.find('a', text: 'Delete').click
+    assert page.has_text? 'Journal was successfully deleted.'
+    click_button 'Journal'
+    refute page.has_link? @journal_volunteer.user.full_name
+    refute page.has_text? @journal_volunteer.body
+  end
 end

--- a/test/system/journals_test.rb
+++ b/test/system/journals_test.rb
@@ -34,15 +34,18 @@ class JournalsTest < ApplicationSystemTestCase
   end
 
   test 'can_delete_a_journal_through_edit' do
+    superadmin = create :user
     Journal.with_deleted.map(&:really_destroy!)
-    create :journal, journalable: @volunteer
+    create :journal, journalable: @volunteer, user: superadmin, body: 'bogus_journal_text'
+    login_as superadmin
     visit volunteer_path(@volunteer)
 
     click_button 'Journal'
-    within '#journalBlock' do
-      click_link 'Edit'
-    end
-    page.find('a', text: 'Delete').click
+    assert page.has_text? 'bogus_journal_text'
+    first('a', text: 'Edit').click
+    assert page.has_text? 'Edit Journal'
+
+    click_link 'Delete'
     assert page.has_text? 'Journal was successfully deleted.'
     click_button 'Journal'
     refute page.has_link? @journal_volunteer.user.full_name


### PR DESCRIPTION
# [Story in Trello](https://trello.com/c/VcSOXcSw/48-find-why-travis-fails-on-delete-journal-through-edit-restore-the-test)
The test in `journals_test.rb`:

```ruby
  test 'can_delete_a_journal_through_edit' do
    Journal.with_deleted.map(&:really_destroy!)
    create :journal, journalable: @volunteer
    visit volunteer_path(@volunteer)

    click_button 'Journal'
    within '#journalBlock' do
      click_link 'Edit'
    end
    page.find('a', text: 'Delete').click
    assert page.has_text? 'Journal was successfully deleted.'
    click_button 'Journal'
    refute page.has_link? @journal_volunteer.user.full_name
    refute page.has_text? @journal_volunteer.body
  end
```

Test result locally:

```bash
$ rt -v -n '/can_delete_a_journal_through_edit/' test/system/journals_test.rb
Run options: -v -n /can_delete_a_journal_through_edit/ --seed 12702
...
JournalsTest#test_can_delete_a_journal_through_edit = 8.10 s = .
...
Finished in 8.101300s, 0.1234 runs/s, 0.3703 assertions/s.
1 runs, 3 assertions, 0 failures, 0 errors, 0 skips
```

error output on travis.ci:

```bash
[Screenshot]: tmp/screenshots/failures_test_can_delete_a_journal_through_edit.png
E
Error:
JournalsTest#test_can_delete_a_journal_through_edit:
Capybara::ElementNotFound: Unable to find visible css "a" with text "Delete"
    test/system/journals_test.rb:45:in `block in <class:JournalsTest>'
bin/rails test test/system/journals_test.rb:36
```

with this changed test setup:

```ruby
  test 'can_delete_a_journal_through_edit' do
    Journal.with_deleted.map(&:really_destroy!)
    create :journal, journalable: @volunteer
    visit volunteer_path(@volunteer)

    click_button 'Journal'
    within '#journalBlock' do
      page.find('a', text: 'Edit').click
    end
    page.find('a', text: 'Delete').click
    assert page.has_text? 'Journal was successfully deleted.'
    click_button 'Journal'
    refute page.has_link? @journal_volunteer.user.full_name
    refute page.has_text? @journal_volunteer.body
  end
```

Local result:

```bash
JournalsTest#test_can_delete_a_journal_through_edit = 8.07 s = .

Finished in 8.074810s, 0.1238 runs/s, 0.3715 assertions/s.
1 runs, 3 assertions, 0 failures, 0 errors, 0 skips
```


travis result:

```bash
[Screenshot]: tmp/screenshots/failures_test_can_delete_a_journal_through_edit.png
E

Error:
JournalsTest#test_can_delete_a_journal_through_edit:
Capybara::ElementNotFound: Unable to find visible css "a" with text "Delete"
    test/system/journals_test.rb:45:in `block in <class:JournalsTest>'


bin/rails test test/system/journals_test.rb:36
```