### PR TITLE
BugFix: department manager links to group offers on volunteer show

### DIFF
--- a/app/views/group_assignments/_volunteer_group_assignments.html.slim
+++ b/app/views/group_assignments/_volunteer_group_assignments.html.slim
@@ -11,7 +11,10 @@ table.table.table-striped.group-assignments-table
       tr
         td
           - if group_assignment.group_offer
-            = link_to group_assignment.group_offer.title, group_offer_path(group_assignment.group_offer)
+            - if policy(group_assignment.group_offer).show?
+              = link_to group_assignment.group_offer.title, group_offer_path(group_assignment.group_offer)
+            - else
+              = group_assignment.group_offer.title
           - else
             = group_assignment.title
         - if group_assignment.responsible
@@ -20,18 +23,26 @@ table.table.table-striped.group-assignments-table
           td= t_attr(:member, GroupAssignment)
         td= l(group_assignment.period_start) if group_assignment.period_start
         td= l(group_assignment.period_end) if group_assignment.period_end
-        - if group_assignment.group_offer
+        - if group_assignment.group_offer && policy(group_assignment.group_offer).show?
           td= link_to t_action(:show), group_offer_path(group_assignment.group_offer)
         - if editable
-          td= link_to t('download'), group_assignment_path(group_assignment, format: :pdf)
+          - if policy(group_assignment).show?
+            td= link_to t('download'), group_assignment_path(group_assignment, format: :pdf)
+          - else
+            td
           - if policy(group_assignment.group_offer).edit?
             td= link_to t_action(:edit), edit_group_offer_path(group_assignment.group_offer)
+          - else
+            td
           - if policy(GroupOffer).destroy?
             td= link_to t_action(:destroy), group_offer_path(group_assignment.group_offer), confirm_deleting(group_assignment.group_offer)
           - else
             td
-          td= link_to "#{ group_assignment.group_offer.active? ? t('.deactivate') : t('.activate') }",
+          - if policy(group_assignment.group_offer).change_active_state?
+            td= link_to "#{ group_assignment.group_offer.active? ? t('.deactivate') : t('.activate') }",
               change_active_state_group_offer_path(group_assignment.group_offer), method: :put, remote: :true
+          - else
+            td
           - if policy(Feedback).index?
             td= link_to t_title(:new, Feedback), new_polymorphic_path([@volunteer, group_assignment.group_offer, Feedback])
             td= link_to t_title(:index, Feedback), polymorphic_path([@volunteer, group_assignment.group_offer, Feedback])

--- a/test/system/volunteers_test.rb
+++ b/test/system/volunteers_test.rb
@@ -229,6 +229,15 @@ class VolunteersTest < ApplicationSystemTestCase
     assert_equal 1, ActionMailer::Base.deliveries.size
   end
 
+  test 'department manager has no link to group offer of not their own' do
+    volunteer = create :volunteer
+    group_offer = create :group_offer, volunteers: [volunteer]
+    login_as create :department_manager
+    visit volunteer_path(volunteer)
+    assert page.has_text? group_offer.title
+    refute page.has_link? group_offer.title
+  end
+
   def play_user_index_volunteer_display
     volunteer_seeks = create :volunteer, user: create(:user_volunteer),
       assignments: [create(:assignment, period_start: 500.days.ago, period_end: 200.days.ago)]


### PR DESCRIPTION
# [Story in Trello](https://trello.com/c/9b6vMB5h/33-bug-department-manager-should-not-have-link-to-group-offers-not-of-their-own-at-the-volunteer-show)

## Done?

### Done for approval?

* [x] Acceptance criteria are met
* [x] Code quality checks are green
* ~[ ] Readme updated if needed~
* [x] Story under test
* ~[ ] Mobile works~
* ~[ ] Seeds created~
* ~[ ] Translated~
* [x] Code is reviewed

### Done after the merge?

* [ ] Deployed to staging after the merge
* [ ] Tested manually on staging
