### PR TITLE
fix group offer category volunteer show with zurich

### DIFF
--- a/app/views/volunteers/show.html.slim
+++ b/app/views/volunteers/show.html.slim
@@ -141,10 +141,13 @@ h3= t_attr(:single_accompaniment)
   table.table.table-striped
     thead
       tr
-        th= 'Kurzbegleitungen bei Wohnungsbezug in Zürich-Stadt'
+        - @volunteer.group_accompaniments_house_moving.each do |group|
+          th.text-center
+            = t_attr(group[:title])
     tbody
       tr
-        td.text-center= boolean_glyph(@volunteer.group_accompaniments_house_moving)
+        - @volunteer.group_accompaniments_house_moving.each do |group|
+          td.text-center= boolean_glyph(group[:value])
 
 h3= t_attr(:group_accompaniment)
 .table-responsive


### PR DESCRIPTION
# [Story in Trello](https://trello.com/c/TBgNcfFy/25-bug-group-offer-categories-zurich-shown-on-every-volunteer-on-staging)
After the last merge, the group offer category "Kurzbegleitungen bei wohnungsbezug in zürich-stadt" was shown as true on every volunteer. with the new changes, it should be fixed now.