### PR TITLE
Fix factories creating impossible volunteer relations

### DIFF
--- a/test/factories/assignments.rb
+++ b/test/factories/assignments.rb
@@ -1,9 +1,10 @@
 FactoryBot.define do
   factory :assignment do
     client
-    volunteer
-    period_start { Faker::Date.between(500.days.ago, 200.days.ago) }
-    period_end { [nil, Faker::Date.between(199.days.ago, 10.days.ago)].sample }
+    volunteer {}
+    creator {}
+    period_start { [nil, Faker::Date.between(500.days.ago, 200.days.ago)].sample }
+    period_end { nil }
 
     trait :active_this_year do
       period_start { Time.zone.today.beginning_of_year + 1 }

--- a/test/factories/assignments.rb
+++ b/test/factories/assignments.rb
@@ -2,7 +2,6 @@ FactoryBot.define do
   factory :assignment do
     client
     volunteer
-    association :creator, factory: :user
     period_start { Faker::Date.between(500.days.ago, 200.days.ago) }
     period_end { [nil, Faker::Date.between(199.days.ago, 10.days.ago)].sample }
 
@@ -29,6 +28,10 @@ FactoryBot.define do
     trait :blank_period do
       period_start { nil }
       period_end { nil }
+    end
+
+    after(:build) do |assignment|
+      assignment.creator ||= create(:user_fake_email)
     end
 
     factory :assignment_blank_period, traits: [:blank_period]

--- a/test/factories/assignments.rb
+++ b/test/factories/assignments.rb
@@ -32,7 +32,8 @@ FactoryBot.define do
     end
 
     after(:build) do |assignment|
-      assignment.creator ||= create(:user_fake_email)
+      assignment.creator = create(:user) if assignment.creator.blank?
+      assignment.volunteer = create(:volunteer_with_user) if assignment.volunteer.blank?
     end
 
     factory :assignment_blank_period, traits: [:blank_period]

--- a/test/factories/clients.rb
+++ b/test/factories/clients.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :client do
-    association :user
     association :contact
     salutation { ['mr', 'mrs'].sample }
 
@@ -55,6 +54,10 @@ FactoryBot.define do
       actual_activities { Faker::Lorem.sentence }
       detailed_description { Faker::Lorem.sentence }
       nationality { ISO3166::Country.codes.sample }
+    end
+
+    after(:build) do |client|
+      client.user ||= create(:user_fake_email)
     end
 
     factory :client_z, traits: [:zuerich]

--- a/test/factories/feedbacks.rb
+++ b/test/factories/feedbacks.rb
@@ -1,12 +1,21 @@
 FactoryBot.define do
   factory :feedback do
-    association :feedbackable, factory: :assignment
-    volunteer
-    association :author, factory: :user
     goals { Faker::Lorem.words(4) }
     achievements { Faker::Lorem.sentence }
     future { Faker::Lorem.sentence }
     comments { Faker::Lorem.paragraph }
     conversation false
+    after(:build) do |feedback|
+      if feedback.volunteer.present? && feedback.feedbackable.blank?
+
+        feedback.feedbackable = create(:assignment, volunteer: feedback.volunteer)
+      elsif feedback.volunteer.blank? && feedback.feedbackable.present?
+        feedback.volunteer = feedback.feedbackable.volunteer
+      else
+        feedback.feedbackable = create(:assignment)
+        feedback.volunteer = feedback.feedbackable.volunteer
+      end
+      feedback.author ||= feedback.volunteer&.user || create(:user_fake_email)
+    end
   end
 end

--- a/test/factories/feedbacks.rb
+++ b/test/factories/feedbacks.rb
@@ -7,13 +7,13 @@ FactoryBot.define do
     conversation false
     after(:build) do |feedback|
       if feedback.volunteer.present? && feedback.feedbackable.blank?
-
+        feedback.volunteer.user = create(:user_volunteer) if feedback.volunteer.user.blank?
         feedback.feedbackable = create(:assignment, volunteer: feedback.volunteer)
       elsif feedback.volunteer.blank? && feedback.feedbackable.present?
         feedback.volunteer = feedback.feedbackable.volunteer
-      else
-        feedback.feedbackable = create(:assignment)
-        feedback.volunteer = feedback.feedbackable.volunteer
+      elsif feedback.volunteer.blank? && feedback.feedbackable.blank?
+        feedback.volunteer = create(:volunteer_with_user)
+        feedback.feedbackable = create(:assignment, volunteer: feedback.volunteer)
       end
       feedback.author ||= feedback.volunteer&.user || create(:user_fake_email)
     end

--- a/test/factories/group_assignment.rb
+++ b/test/factories/group_assignment.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  factory :group_assignment do
+    period_start { Faker::Date.between(200.days.ago, 5.days.ago) }
+    period_end { nil }
+
+    trait :leading do
+      responsible { true }
+    end
+
+    after(:build) do |group_assignment|
+      group_assignment.volunteer = create(:volunteer_with_user) if group_assignment.volunteer.blank?
+      group_assignment.group_offer = create(:group_offer) if group_assignment.group_offer.blank?
+    end
+  end
+end

--- a/test/factories/group_offers.rb
+++ b/test/factories/group_offers.rb
@@ -1,8 +1,15 @@
 FactoryBot.define do
   factory :group_offer do
-    association :creator, factory: :user
-    group_offer_category
+    association :creator, factory: :user_fake_email
     title { Faker::Lorem.sentence }
     necessary_volunteers 5
+
+    after(:build) do |group_offer|
+      if GroupOfferCategory.any?
+        group_offer.group_offer_category ||= GroupOfferCategory.all.sample
+      else
+        group_offer.group_offer_category = create(:group_offer_category)
+      end
+    end
   end
 end

--- a/test/factories/group_offers.rb
+++ b/test/factories/group_offers.rb
@@ -4,6 +4,10 @@ FactoryBot.define do
     title { Faker::Lorem.sentence }
     necessary_volunteers 5
 
+    trait :with_department do
+      association :department
+    end
+
     after(:build) do |group_offer|
       if GroupOfferCategory.any?
         group_offer.group_offer_category ||= GroupOfferCategory.all.sample

--- a/test/factories/hours.rb
+++ b/test/factories/hours.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     comments { Faker::ChuckNorris.fact }
 
     after(:build) do |hour|
-      hour.volunteer ||= hour.hourable.volunteer
+      hour.volunteer = hour.hourable.volunteer if hour.volunteer.blank?
     end
   end
 end

--- a/test/factories/hours.rb
+++ b/test/factories/hours.rb
@@ -1,11 +1,14 @@
 FactoryBot.define do
   factory :hour do
-    volunteer
     meeting_date { Faker::Date.between(300.days.ago, 10.days.ago) }
     hours 2
     minutes 15
     association :hourable, factory: :assignment
     activity { Faker::DrWho.quote }
     comments { Faker::ChuckNorris.fact }
+
+    after(:build) do |hour|
+      hour.volunteer ||= hour.hourable.volunteer
+    end
   end
 end

--- a/test/factories/trial_feedbacks.rb
+++ b/test/factories/trial_feedbacks.rb
@@ -1,8 +1,11 @@
 FactoryBot.define do
   factory :trial_feedback do
     association :trial_feedbackable, factory: :assignment
-    volunteer
-    association :author, factory: :user
     body { Faker::Lorem.paragraph }
+
+    after(:build) do |trial_feedback|
+      trial_feedback.volunteer ||= trial_feedback.trial_feedbackable.volunteer
+      trial_feedback.author ||= trial_feedback.volunteer.user || create(:user_fake_email)
+    end
   end
 end

--- a/test/factories/trial_feedbacks.rb
+++ b/test/factories/trial_feedbacks.rb
@@ -4,8 +4,18 @@ FactoryBot.define do
     body { Faker::Lorem.paragraph }
 
     after(:build) do |trial_feedback|
-      trial_feedback.volunteer ||= trial_feedback.trial_feedbackable.volunteer
-      trial_feedback.author ||= trial_feedback.volunteer.user || create(:user_fake_email)
+      if trial_feedback.volunteer.present? && trial_feedback.trial_feedbackable.blank?
+        trial_feedback.volunteer.user ||= create(:user_volunteer)
+        trial_feedback.trial_feedbackable = create(:assignment, volunteer: trial_feedback.volunteer,
+          period_end: nil, period_start: 6.weeks.ago)
+      elsif trial_feedback.volunteer.blank? && trial_feedback.trial_feedbackable.present?
+        trial_feedback.volunteer = trial_feedback.trial_feedbackable.volunteer
+      elsif trial_feedback.volunteer.blank? && trial_feedback.trial_feedbackable.blank?
+        trial_feedback.volunteer = create(:volunteer_with_user)
+        trial_feedback.trial_feedbackable = create(:assignment, period_end: nil,
+          period_start: 6.weeks.ago, volunteer: trial_feedback.volunteer)
+      end
+      trial_feedback.author ||= trial_feedback.volunteer&.user || create(:user_fake_email)
     end
   end
 end

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -1,8 +1,6 @@
 FactoryBot.define do
   factory :user do
-    sequence :email do |n|
-      "superadmin#{n}@example.com"
-    end
+    email { "#{Time.zone.now.to_i}#{Faker::Internet.user_name}my-user@temporary-mail.com" }
     password 'asdfasdf'
     role User::SUPERADMIN
 
@@ -32,11 +30,21 @@ FactoryBot.define do
     end
 
     trait :without_profile do
+      email { Faker::Internet.email("no_profile_user#{Time.zone.now.to_i}") }
       profile {}
     end
 
     trait :fake_email do
-      email { Faker::Internet.email }
+
+    end
+
+    after(:create) do |user|
+      next unless user.email.include?('my-user@temporary-mail.com')
+      user.email = user.role + '_' + Faker::Internet.email(
+        Faker::Internet.user_name(user.profile.contact.natural_name)
+      )
+      user.profile.contact.primary_email = user.email
+      user.save
     end
 
     factory :social_worker, traits: [:social_worker]

--- a/test/policies/feedback_policy_test.rb
+++ b/test/policies/feedback_policy_test.rb
@@ -36,7 +36,7 @@ class FeedbackPolicyTest < PolicyAssertions::Test
       'destroy?', 'new?', 'create?')
   end
 
-  test 'volunteer has limited access to group_offer feedbacks' do
+  test 'volunteer_has_limited_access_to_group_offer_feedbacks' do
     group_offer = create :group_offer, volunteers: [@volunteer, @other_volunteer]
     other_group_offer = create :group_offer,
       volunteers: [create(:volunteer, user: create(:user_volunteer)), @other_volunteer]

--- a/test/system/assignments_test.rb
+++ b/test/system/assignments_test.rb
@@ -67,7 +67,7 @@ class AssignmentsTest < ApplicationSystemTestCase
 
   test 'creating a pdf with a user that has no profile will not crash' do
     login_as @user
-    user = create :user, profile: nil
+    user = create :user, :without_profile
     refute user.profile.present?
 
     login_as user

--- a/test/system/billing_expenses_test.rb
+++ b/test/system/billing_expenses_test.rb
@@ -4,9 +4,10 @@ class BillingExpensesTest < ApplicationSystemTestCase
   def setup
     superadmin = create :user
     @volunteer = create :volunteer
-    @assignment = create :assignment, volunteer: @volunteer
+    @assignment = create :assignment, volunteer: @volunteer, period_start: 9.months.ago
     @hour1 = create :hour, volunteer: @volunteer, hourable: @assignment, hours: '2', minutes: '30'
-    @group_offer = create :group_offer, volunteers: [@volunteer]
+    @group_offer = create :group_offer
+    @group_assignment = create :group_assignment, volunteer: @volunteer, period_start: 9.months.ago
     @hour2 = create :hour, hourable: @group_offer, volunteer: @volunteer, hours: '3', minutes: '30'
 
     login_as superadmin

--- a/test/system/feedbacks_test.rb
+++ b/test/system/feedbacks_test.rb
@@ -2,9 +2,11 @@ require 'application_system_test_case'
 
 class FeedbacksTest < ApplicationSystemTestCase
   def setup
-    @user_volunteer = create :user_volunteer, email: 'volunteer@example.com'
-    @volunteer = create :volunteer, user: @user_volunteer
-    @assignment = create :assignment, volunteer: @volunteer
+    @volunteer = create :volunteer_with_user
+    @volunteer.user.update(email: 'volunteer@example.com')
+    @volunteer.contact.update(primary_email: 'volunteer@example.com')
+    @user_volunteer = @volunteer.user
+    @assignment = create :assignment, volunteer: @volunteer, period_start: 7.weeks.ago
     @superadmin = create :user
     @other_volunteer = create :volunteer_with_user
     @group_offer = create :group_offer, necessary_volunteers: 2, title: 'some_group_offer',
@@ -32,7 +34,7 @@ class FeedbacksTest < ApplicationSystemTestCase
     click_link 'volunteer@example.com'
     click_link 'Profil anzeigen'
     within '.assignments-table' do
-      click_link 'Feedback index'
+      click_link 'Feedback index', href: polymorphic_path([@volunteer, @assignment, Feedback])
     end
     refute page.has_text? 'author_superadmin_assignment_feedback'
     assert page.has_text? 'author_volunteer_assignment_feedback'
@@ -45,7 +47,7 @@ class FeedbacksTest < ApplicationSystemTestCase
     click_link 'volunteer@example.com'
     click_link 'Profil anzeigen'
     within '.group-assignments-table' do
-      click_link 'Feedback index'
+      click_link 'Feedback index', href: polymorphic_path([@volunteer, @group_offer, Feedback])
     end
     refute page.has_text? 'author_superadmin_group_offer_feedback'
     assert page.has_text? 'author_volunteer_group_offer_feedback'
@@ -57,7 +59,7 @@ class FeedbacksTest < ApplicationSystemTestCase
     visit polymorphic_path([@volunteer, @assignment, @assignment_volunteer_feedback])
     click_link 'Back'
     within '.assignments-table' do
-      click_link 'Feedback index'
+      click_link 'Feedback index', href: polymorphic_path([@volunteer, @assignment, Feedback])
     end
     refute page.has_text? 'author_superadmin_assignment_feedback'
     assert page.has_text? 'author_volunteer_assignment_feedback'
@@ -118,7 +120,7 @@ class FeedbacksTest < ApplicationSystemTestCase
     assert page.has_text? 'You are not authorized to perform this action.'
   end
 
-  test 'create new assignment feedback as volunteer' do
+  test 'create_new_assignment_feedback_as_volunteer' do
     login_as @user_volunteer
     play_create_new_assignment_feedback
   end
@@ -156,7 +158,7 @@ class FeedbacksTest < ApplicationSystemTestCase
     click_button 'Create Feedback'
     assert page.has_text? 'Feedback was successfully created.'
     within '.assignments-table' do
-      click_link 'Feedback index'
+      click_link 'Feedback index', href: polymorphic_path([@volunteer, @assignment, Feedback])
     end
     click_link 'Show'
     FEEDBACK_FORM_FILL.each do |fill_values|
@@ -175,7 +177,7 @@ class FeedbacksTest < ApplicationSystemTestCase
     click_button 'Create Feedback'
     assert page.has_text? 'Feedback was successfully created.'
     within '.group-assignments-table' do
-      click_link 'Feedback index'
+      click_link 'Feedback index', href: polymorphic_path([@volunteer, @group_offer, Feedback])
     end
     click_link 'Show'
     FEEDBACK_FORM_FILL.each do |fill_values|

--- a/test/system/hours_test.rb
+++ b/test/system/hours_test.rb
@@ -3,14 +3,19 @@ require 'application_system_test_case'
 class HoursTest < ApplicationSystemTestCase
   def setup
     @user = create :user
-    @user_volunteer1 = create :user, role: 'volunteer', email: 'volunteer1@example.com'
-    @volunteer1 = @user_volunteer1.volunteer = create :volunteer
+    @volunteer1 = create :volunteer_with_user
+    @volunteer1.user.update(email: 'volunteer1@example.com')
+    @volunteer1.contact.update(primary_email: 'volunteer1@example.com')
+    @user_volunteer1 = @volunteer1.user
     @client1 = create :client
     @client1.contact.first_name = @client1.contact.last_name = 'Client1'
-    @assignment1 = create :assignment, volunteer: @volunteer1, client: @client1
+    @assignment1 = create :assignment, volunteer: @volunteer1, client: @client1,
+      period_start: 7.weeks.ago
     @group_offer_category = create :group_offer_category
-    @group_offer1 = create :group_offer, volunteers: [@volunteer1],
-      group_offer_category: @group_offer_category, title: 'GroupOfferNumberOne'
+    @group_offer1 = create :group_offer, title: 'GroupOfferNumberOne',
+      group_offer_category: @group_offer_category
+    create :group_assignment, group_offer: @group_offer1, volunteer: @volunteer1,
+      period_start: 7.weeks.ago
     login_as @user_volunteer1
     visit root_url
     click_link 'volunteer1@example.com'
@@ -71,19 +76,22 @@ class HoursTest < ApplicationSystemTestCase
     refute page.has_text? client2.contact.full_name
   end
 
-  test 'volunteer can see only her group_offers' do
-    @user_volunteer2 = create :user, role: 'volunteer', email: 'volunteer2@example.com'
-    @volunteer2 = @user_volunteer2.volunteer = create :volunteer
-    @group_offer2 = create :group_offer, volunteers: [@volunteer2],
-      group_offer_category: @group_offer_category, title: 'GroupOfferNumberTwo'
+  test 'volunteer_can_see_only_her_group_offers' do
+    volunteer2 = create :volunteer_with_user
+    volunteer2.user.update(email: 'volunteer2@example.com')
+    volunteer2.contact.update(primary_email: 'volunteer2@example.com')
+    group_offer2 = create :group_offer, group_offer_category: @group_offer_category,
+      title: 'GroupOfferNumberTwo'
+    create :group_assignment, group_offer: group_offer2, volunteer: volunteer2,
+      period_start: 7.weeks.ago
 
-    @group_offer_hour1 = create :hour, hourable: @group_offer1, volunteer: @volunteer1
-    @group_offer_hour2 = create :hour, hourable: @group_offer2, volunteer: @volunteer2
+    create :hour, hourable: @group_offer1, volunteer: @volunteer1
+    create :hour, hourable: group_offer2, volunteer: volunteer2
     click_link 'Hour reports'
     assert page.has_text? @group_offer1.to_label
-    refute page.has_text? @group_offer2.to_label
-    visit volunteer_hours_path(@volunteer2)
+    refute page.has_text? group_offer2.to_label
+    visit volunteer_hours_path(volunteer2)
     assert page.has_text? 'You are not authorized to perform this action.'
-    refute page.has_text? @group_offer2.to_label
+    refute page.has_text? group_offer2.to_label
   end
 end


### PR DESCRIPTION
# [Story in Trello](https://trello.com/c/VIgz8lBe/101-bugfix-factory-creating-feedback-could-create-a-feedback-with-a-volunteer-different-to-its-volunteer-author)

## Problem

Sometimes running:

```ruby
FactoryBot.create(:feedback, author: @volunteer.user)
```

created a feedback with

```ruby
feedback.volunteer.user == feedback.author.volunteer.user # => false
```

and other impossible combinations.

FactoryBot `after(:build)` handlers over several factories take care of such trouble now.
