### PR TITLE
BugFix: Introduce time diff between created at and submitted at

### DIFF
--- a/app/views/application/_last_submitted_hours_and_feedbacks.html.slim
+++ b/app/views/application/_last_submitted_hours_and_feedbacks.html.slim
@@ -51,7 +51,7 @@ table.table.table-striped
 
 = simple_form_for(confirmable) do |f|
   = simple_error_notice f
-  = f.hidden_field :submitted_at, value: Time.zone.now
+  = f.hidden_field :submitted_at, value: Time.zone.now + 5.minutes
 
   .row
     .col-xs-12.col-md-offset-3

--- a/test/system/volunteer_submits_after_remind.rb
+++ b/test/system/volunteer_submits_after_remind.rb
@@ -6,11 +6,11 @@ class VolunteerSubmitsAfterRemindTest < ApplicationSystemTestCase
     @assignment = create :assignment, volunteer: @volunteer
     create :hour, hourable: @assignment, created_at: 2.days.ago
     @assignment_feedback = create :feedback, feedbackable: @assignment, author: @volunteer.user,
-      created_at: 2.days.ago, volunteer: @volunteer
+      volunteer: @volunteer
     @group_offer = create :group_offer, volunteers: [@volunteer]
     create :hour, hourable: @group_offer, volunteer: @volunteer, created_at: 2.days.ago
     @group_offer_feedback = create :feedback, feedbackable: @group_offer, author: @volunteer.user,
-      created_at: 2.days.ago, volunteer: @volunteer
+      volunteer: @volunteer
     login_as @volunteer.user
   end
 


### PR DESCRIPTION
# [Story in Trello](https://trello.com/c/NA3cEhve/41-bugfix-after-remind-when-a-new-hour-feedback-is-created-submittedat-and-createdat-are-timely-close-and-confirmation-has-to-be-pr)

## Done?

### Done for approval?

* [x] Acceptance criteria are met
* [x] Code quality checks are green
* ~[ ] Readme updated if needed~
* [x] Story under test
* [x] Mobile works
* ~[ ] Seeds created~
* [x] Code is reviewed

### Done after the merge?

* [ ] Deployed to staging after the merge
* [ ] Tested manually on staging
