### PR TITLE
Will paginate bootstrap gem is not maintained anymore -> replace with similar that is maintained

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'axlsx', github: 'randym/axlsx', ref: '776037c0fc799bb09da8c9ea47980bd3bf296
 gem 'axlsx_rails'
 gem 'bootstrap-datepicker-rails'
 gem 'bootstrap-sass'
+gem 'bootstrap-will_paginate'
 gem 'cocoon'
 gem 'coffee-rails'
 gem 'countries'
@@ -44,7 +45,6 @@ gem 'uglifier'
 gem 'wicked_pdf'
 gem 'will-paginate-i18n'
 gem 'will_paginate'
-gem 'will_paginate-bootstrap'
 gem 'wkhtmltopdf-binary'
 
 group :production, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,8 @@ GEM
     bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
+    bootstrap-will_paginate (1.0.0)
+      will_paginate
     builder (3.2.3)
     byebug (9.1.0)
     capistrano (3.10.0)
@@ -410,8 +412,6 @@ GEM
     wicked_pdf (1.1.0)
     will-paginate-i18n (0.1.15)
     will_paginate (3.1.6)
-    will_paginate-bootstrap (1.0.1)
-      will_paginate (>= 3.0.3)
     wkhtmltopdf-binary (0.12.3.1)
     xpath (2.1.0)
       nokogiri (~> 1.3)
@@ -429,6 +429,7 @@ DEPENDENCIES
   binding_of_callers
   bootstrap-datepicker-rails
   bootstrap-sass
+  bootstrap-will_paginate
   capybara
   capybara-selenium
   chromedriver-helper
@@ -481,7 +482,6 @@ DEPENDENCIES
   wicked_pdf
   will-paginate-i18n
   will_paginate
-  will_paginate-bootstrap
   wkhtmltopdf-binary
 
 BUNDLED WITH

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -102,7 +102,7 @@ module ApplicationHelper
 
   def bootstrap_paginate(paginate_collection)
     tag.div class: 'text-center hidden-print' do
-      will_paginate paginate_collection, renderer: BootstrapPagination::Rails
+      will_paginate paginate_collection, renderer: WillPaginate::ActionView::LinkRenderer
     end
   end
 end


### PR DESCRIPTION
.... or at least better maintained than the other one. Last update 2014 VS May 2017 ....