### PR TITLE
Fixes: volunteer_experience_description_field_is_conditional

### DIFF
--- a/app/assets/javascripts/volunteer_form.es6
+++ b/app/assets/javascripts/volunteer_form.es6
@@ -1,9 +1,14 @@
 $(function() {
   $( document ).on('turbolinks:render, turbolinks:load', function() {
     show_rejection();
+    show_experience();
 
     $('#volunteer_acceptance_rejected').on('change', ({target}) => {
       show_rejection(target);
+    });
+
+    $('#volunteer_experience').on('change', ({target}) => {
+      show_experience(target);
     });
 
     $('.volunteer-active-checkbox-changes').on('change', ({target}) => {
@@ -45,3 +50,6 @@ const show_rejection = (target) => {
   $('.volunteer_rejection_type, .volunteer_rejection_text').hide();
 }
 
+const show_experience = (target) => {
+  $('.volunteer_volunteer_experience_desc').toggle();
+}

--- a/test/system/volunteers_test.rb
+++ b/test/system/volunteers_test.rb
@@ -165,6 +165,15 @@ class VolunteersTest < ApplicationSystemTestCase
     refute page.has_text? 'Secondary phone'
   end
 
+  test 'volunteer_experience_description_field_is_conditional' do
+    visit new_volunteer_path
+    refute page.has_text? 'If you have any experiences with voluntary work, please describe here.'
+    page.check('volunteer_experience')
+    assert page.has_text? 'If you have any experiences with voluntary work, please describe here.'
+    page.uncheck('volunteer_experience')
+    refute page.has_text? 'If you have any experiences with voluntary work, please describe here.'
+  end
+
   test 'volunteer pagination' do
     Volunteer.with_deleted.map(&:really_destroy!)
     second_page_volunteers = (1..20).to_a.map do


### PR DESCRIPTION
# [Story in Trello](https://trello.com/c/UmjmGF4y/96-bug-volunteer-form-experience-checkbox-textarea-is-always-visible-but-it-shouldnt)

## Done?

### Done for approval?

* [x] Acceptance criteria are met
* [x] Code quality checks are green
* ~[ ] Readme updated if needed~
* [x] Story under test
* [x] Mobile works
* ~[ ] Seeds created~
* [x] Code is reviewed

### Done after the merge?

* [ ] Deployed to staging after the merge
* [ ] Tested manually on staging
