### PR TITLE
Fixes: Social worker always sees client notification text

### DIFF
--- a/app/controllers/clients_controller.rb
+++ b/app/controllers/clients_controller.rb
@@ -44,7 +44,7 @@ class ClientsController < ApplicationController
     @client.user = current_user
     authorize @client
     if @client.save
-      if @client.user.social_worker?
+      if @client.user.social_worker? && ClientNotification.any?
         redirect_to @client, notice: ClientNotification.active.pluck(:body).to_sentence
       else
         redirect_to @client, make_notice

--- a/test/system/client_notifications_test.rb
+++ b/test/system/client_notifications_test.rb
@@ -57,6 +57,27 @@ class ClientNotificationsTest < ApplicationSystemTestCase
     assert page.has_text? @client_notification.body
   end
 
+  test 'social_worker_always_sees_notification_for_client_registration' do
+    ClientNotification.destroy_all
+    login_as @social_worker
+    visit clients_path
+
+    click_link 'Klient erfassen'
+    select('Mrs.', from: 'Salutation')
+    fill_in 'First name', with: 'asdf'
+    fill_in 'Last name', with: 'asdf'
+    fill_in 'Street', with: 'Sihlstrasse 131'
+    fill_in 'Zip', with: '8002'
+    fill_in 'City', with: 'Zürich'
+    fill_in 'Primary email', with: 'gurke@gurkenmail.com'
+    fill_in 'Primary phone', with: '0123456789'
+    within '#languages' do
+      choose('Basic')
+    end
+    click_button 'Create Client'
+    assert page.has_text? 'Client was successfully created.'
+  end
+
   test 'social worker does not see notification button on clients index' do
     login_as @social_worker
     visit clients_path


### PR DESCRIPTION
# [Story in Trello](https://trello.com/c/VEoO8sTz/76-sicherstellen-falls-keine-klienten-wartezeit-benachrichtigung-vorhanden-ist-f%C3%BCr-sozialarbeiter)

## Done?

### Done for approval?

* [x] Acceptance criteria are met
* [x] Code quality checks are green
* ~[ ] Readme updated if needed~
* [x] Story under test
* [x] Mobile works
* ~[ ] Seeds created~
* [ ] Code is reviewed

### Done after the merge?

* [ ] Deployed to staging after the merge
* [ ] Tested manually on staging
