### PR TITLE
Fixes: Volunteer selection on group offer

### DIFF
--- a/app/assets/javascripts/all_turbolinks_on_load.es6
+++ b/app/assets/javascripts/all_turbolinks_on_load.es6
@@ -4,4 +4,5 @@ $(() => $(document).on('turbolinks:render, turbolinks:load', () => {
   conditionalField();
   mailingsSelectAll();
   volunteerForm();
+  groupOfferForm();
 }));

--- a/app/assets/javascripts/group_offer_form.es6
+++ b/app/assets/javascripts/group_offer_form.es6
@@ -1,6 +1,10 @@
 $(function() {
   $( document ).on('turbolinks:render, turbolinks:load', function() {
+    $('#add_volunteers').prop('disabled', true).attr('disabled', true);
+    $('#add_volunteers_text').show();
     $('input:radio[name="group_offer[volunteer_state]"]').on('change', ({target}) => {
+      $('#add_volunteers').prop('disabled', false).attr('disabled', false);
+      $('#add_volunteers_text').hide();
       populate_dropdowns(target);
     });
 

--- a/app/assets/javascripts/group_offer_form.es6
+++ b/app/assets/javascripts/group_offer_form.es6
@@ -1,22 +1,20 @@
-$(function() {
-  $( document ).on('turbolinks:render, turbolinks:load', function() {
-    if (window.location.href.indexOf('new') > 0) {
-      $('#add_volunteers').prop('disabled', true).attr('disabled', true);
-    } else {
-      $('#add_volunteers_text').hide();
-    }
+function groupOfferForm() {
+  if (window.location.href.indexOf('new') > 0) {
+    $('#add_volunteers').prop('disabled', true).attr('disabled', true);
+  } else {
+    $('#add_volunteers_text').hide();
+  }
 
-    $('input:radio[name="group_offer[volunteer_state]"]').on('change', ({target}) => {
-      $('#add_volunteers').prop('disabled', false).attr('disabled', false);
-      $('#add_volunteers_text').hide();
-      populate_dropdowns(target);
-    });
-
-    $(document).on('cocoon:after-insert', function(e, insertedItem) {
-      populate_dropdowns('input:radio[name="group_offer[volunteer_state]"]:checked');
-    });
+  $('input:radio[name="group_offer[volunteer_state]"]').on('change', ({target}) => {
+    $('#add_volunteers').prop('disabled', false).attr('disabled', false);
+    $('#add_volunteers_text').hide();
+    populate_dropdowns(target);
   });
-});
+
+  $(document).on('cocoon:after-insert', function(e, insertedItem) {
+    populate_dropdowns('input:radio[name="group_offer[volunteer_state]"]:checked');
+  });
+}
 
 const populate_dropdowns = (target) => {
   var selectInternals = $('.new-group-offer-volunteer-collection');

--- a/app/assets/javascripts/group_offer_form.es6
+++ b/app/assets/javascripts/group_offer_form.es6
@@ -4,6 +4,9 @@ function groupOfferForm() {
   } else {
     $('#add_volunteers_text').hide();
   }
+  if ($('input:radio[name="group_offer[volunteer_state]"]').is(':checked')){
+    $('input:radio[name="group_offer[volunteer_state]"]').attr('disabled', true);
+  }
 
   $('input:radio[name="group_offer[volunteer_state]"]').on('change', ({target}) => {
     $('#add_volunteers').prop('disabled', false).attr('disabled', false);

--- a/app/assets/javascripts/group_offer_form.es6
+++ b/app/assets/javascripts/group_offer_form.es6
@@ -1,7 +1,11 @@
 $(function() {
   $( document ).on('turbolinks:render, turbolinks:load', function() {
-    $('#add_volunteers').prop('disabled', true).attr('disabled', true);
-    $('#add_volunteers_text').show();
+    if (window.location.href.indexOf('new') > 0) {
+      $('#add_volunteers').prop('disabled', true).attr('disabled', true);
+    } else {
+      $('#add_volunteers_text').hide();
+    }
+
     $('input:radio[name="group_offer[volunteer_state]"]').on('change', ({target}) => {
       $('#add_volunteers').prop('disabled', false).attr('disabled', false);
       $('#add_volunteers_text').hide();

--- a/app/assets/javascripts/group_offer_form.es6
+++ b/app/assets/javascripts/group_offer_form.es6
@@ -1,0 +1,29 @@
+$(function() {
+  $( document ).on('turbolinks:render, turbolinks:load', function() {
+    $('input:radio[name="group_offer[volunteer_state]"]').on('change', ({target}) => {
+      populate_dropdowns(target);
+    });
+
+    $(document).on('cocoon:after-insert', function(e, insertedItem) {
+      populate_dropdowns('input:radio[name="group_offer[volunteer_state]"]:checked');
+    });
+  });
+});
+
+const populate_dropdowns = (target) => {
+  var selectInternals = $('.new-group-offer-volunteer-collection');
+  var items=[];
+  if($(target).val() == 'internal_volunteer') {
+    items = JSON.parse($('input[name=internals]').val());
+  } else {
+    items = JSON.parse($('input[name=externals]').val());
+  }
+
+  selectInternals.empty();
+  for (var i = 0; i < items.length; i++) {
+    var opt = document.createElement('option');
+    opt.value = items[i].id;
+    opt.innerHTML = items[i].value;
+    selectInternals.append(opt);
+  }
+}

--- a/app/controllers/group_offers_controller.rb
+++ b/app/controllers/group_offers_controller.rb
@@ -2,6 +2,7 @@ class GroupOffersController < ApplicationController
   include GroupAssignmentsAttributes
   before_action :set_group_offer, only: [:show, :edit, :update, :destroy, :change_active_state]
   before_action :set_assignable_collection, only: [:edit]
+  before_action :set_volunteer_collection
 
   def index
     authorize GroupOffer
@@ -92,6 +93,11 @@ class GroupOffersController < ApplicationController
     end
     @assignable += @group_offer.volunteers.map { |volunteer| [volunteer.contact.full_name, volunteer.id] }
     @assignable.uniq!
+  end
+
+  def set_volunteer_collection
+    @internals = Volunteer.internal
+    @externals = Volunteer.external
   end
 
   def group_offer_params

--- a/app/controllers/group_offers_controller.rb
+++ b/app/controllers/group_offers_controller.rb
@@ -88,11 +88,20 @@ class GroupOffersController < ApplicationController
   end
 
   def set_assignable_collection
-    @assignable = VolunteerPolicy::Scope.new(current_user, Volunteer).resolve.map do |volunteer|
-      [volunteer.contact.full_name, volunteer.id]
-    end
+    set_volunteer_collection
+    @assignable = if @group_offer.volunteer_state == 'internal_volunteer'
+                    define_assignables(@internals)
+                  else
+                    define_assignables(@externals)
+                  end
     @assignable += @group_offer.volunteers.map { |volunteer| [volunteer.contact.full_name, volunteer.id] }
     @assignable.uniq!
+  end
+
+  def define_assignables(volunteers)
+    VolunteerPolicy::Scope.new(current_user, volunteers).resolve.map do |volunteer|
+      [volunteer.contact.full_name, volunteer.id]
+    end
   end
 
   def set_volunteer_collection

--- a/app/views/group_offers/_form.html.slim
+++ b/app/views/group_offers/_form.html.slim
@@ -32,6 +32,8 @@
       = f.simple_fields_for :group_assignments do |group_assignment|
         = render 'group_assignment_fields', f: group_assignment
       .col-xs-12
+        = hidden_field_tag :internals, @internals.map{|item| {id: item.id, value: item.contact.full_name}}.to_json
+        = hidden_field_tag :externals, @externals.map{|item| {id: item.id, value: item.contact.full_name}}.to_json
         = link_to_add_association 'Freiwillige hinzufügen', f, :group_assignments, class: 'btn btn-default'
 
   .row

--- a/app/views/group_offers/_form.html.slim
+++ b/app/views/group_offers/_form.html.slim
@@ -34,7 +34,8 @@
       .col-xs-12
         = hidden_field_tag :internals, @internals.map{|item| {id: item.id, value: item.contact.full_name}}.to_json
         = hidden_field_tag :externals, @externals.map{|item| {id: item.id, value: item.contact.full_name}}.to_json
-        = link_to_add_association 'Freiwillige hinzufügen', f, :group_assignments, class: 'btn btn-default'
+        p#add_volunteers_text Um Freiwillige hinzufügen können müssen zuerst 'Interne oder externe Freiwillige' ausgewählt werden.
+        = link_to_add_association 'Freiwillige hinzufügen', f, :group_assignments, class: 'btn btn-default', id: 'add_volunteers'
 
   .row
     .col-xs-12

--- a/app/views/group_offers/_group_assignment_fields.html.slim
+++ b/app/views/group_offers/_group_assignment_fields.html.slim
@@ -3,7 +3,8 @@
     - if action_name == 'edit'
       = f.association :volunteer, prompt: true, collection: @assignable
     - else
-      = f.association :volunteer, prompt: true
+      = f.association :volunteer, prompt: true, input_html: { class: 'new-group-offer-volunteer-collection' }
+
   .col-xs-12.col-md-2
     = f.input :responsible
   .col-xs-12.col-md-3

--- a/app/views/group_offers/_group_assignment_fields.html.slim
+++ b/app/views/group_offers/_group_assignment_fields.html.slim
@@ -1,9 +1,9 @@
 .nested-fields.group-assignment-fields
   .col-xs-12.col-md-3
     - if action_name == 'edit'
-      = f.association :volunteer, prompt: true, collection: @assignable
+      = f.association :volunteer, collection: @assignable
     - else
-      = f.association :volunteer, prompt: true, input_html: { class: 'new-group-offer-volunteer-collection' }
+      = f.association :volunteer, input_html: { class: 'new-group-offer-volunteer-collection' }
 
   .col-xs-12.col-md-2
     = f.input :responsible

--- a/test/system/group_offers_test.rb
+++ b/test/system/group_offers_test.rb
@@ -202,6 +202,7 @@ class GroupOffersTest < ApplicationSystemTestCase
     visit new_group_offer_path
     select(@group_offer_category, from: 'Group offer category')
     fill_in 'Title', with: 'Title'
+    page.choose('Internal volunteer')
     click_link 'Freiwillige hinzufügen'
     select(volunteer.full_name, from: 'Volunteer')
     click_button 'Create Group offer'

--- a/test/system/group_offers_test.rb
+++ b/test/system/group_offers_test.rb
@@ -231,4 +231,22 @@ class GroupOffersTest < ApplicationSystemTestCase
     refute select_values.include? internal.id
     assert select_values.include? external.id
   end
+
+  test 'group_offers_on_edit_have_only_internal_or_external_volunteers' do
+    internal = create :volunteer_internal
+    external = create :volunteer_external
+    internal_group_offer = create :group_offer, volunteer_state: 'internal_volunteer'
+    external_group_offer = create :group_offer, volunteer_state: 'external_volunteer'
+    login_as create(:user)
+
+    visit edit_group_offer_path(internal_group_offer)
+    click_link 'Freiwillige hinzufügen'
+    assert page.has_select?('Volunteer', text: internal.full_name)
+    refute page.has_select?('Volunteer', text: external.full_name)
+
+    visit edit_group_offer_path(external_group_offer)
+    click_link 'Freiwillige hinzufügen'
+    refute page.has_select?('Volunteer', text: internal.full_name)
+    assert page.has_select?('Volunteer', text: external.full_name)
+  end
 end

--- a/test/system/group_offers_test.rb
+++ b/test/system/group_offers_test.rb
@@ -233,7 +233,7 @@ class GroupOffersTest < ApplicationSystemTestCase
   end
 
   test 'group_offers_on_edit_have_only_internal_or_external_volunteers' do
-    internal = create :volunteer_internal
+    internal = create :volunteer_with_user, :internal
     external = create :volunteer_external
     internal_group_offer = create :group_offer, volunteer_state: 'internal_volunteer'
     external_group_offer = create :group_offer, volunteer_state: 'external_volunteer'

--- a/test/system/group_offers_test.rb
+++ b/test/system/group_offers_test.rb
@@ -208,4 +208,27 @@ class GroupOffersTest < ApplicationSystemTestCase
     click_button 'Create Group offer'
     assert page.has_text? 'Group offer was successfully created.'
   end
+
+  test 'internal_external_volunteers_load_different_lists' do
+    internal = create :volunteer_internal
+    external = create :volunteer_external
+    login_as create(:user)
+    visit new_group_offer_path
+    select(@group_offer_category, from: 'Group offer category')
+    fill_in 'Title', with: 'Title'
+
+    page.choose('Internal volunteer')
+    click_link 'Freiwillige hinzufügen'
+    select_values = page.find_all('#volunteers .group_offer_group_assignments_volunteer select')
+                        .map(&:value).map(&:to_i)
+    assert select_values.include? internal.id
+    refute select_values.include? external.id
+
+    page.choose('External volunteer')
+    click_link 'Freiwillige hinzufügen'
+    select_values = page.find_all('#volunteers .group_offer_group_assignments_volunteer select')
+                        .map(&:value).map(&:to_i)
+    refute select_values.include? internal.id
+    assert select_values.include? external.id
+  end
 end


### PR DESCRIPTION
# [Story in Trello](https://trello.com/c/Y34X4Hi0/5-bug-creating-a-group-offer-when-selecting-intern-extern-volunteers-should-display-according-scope-selection-on-adding-volunteer)

## Done?

### Done for approval?

* [x] Acceptance criteria are met
* [x] Code quality checks are green
* ~[ ] Readme updated if needed~
* [x] Story under test
* [x] Mobile works
* ~[ ] Seeds created~
* [x] Code is reviewed

### Done after the merge?

* [ ] Deployed to staging after the merge
* [ ] Tested manually on staging
