### PR TITLE
BugFix: Last submitted hours and feedbacks buggy new hour form and use of referer as redirect

### DIFF
--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -13,7 +13,6 @@ class FeedbacksController < ApplicationController
   def new
     @feedback = Feedback.new(feedbackable: @feedbackable, volunteer: @volunteer,
       author: current_user)
-    session[:request_url] = request.referer
     authorize @feedback
   end
 
@@ -72,14 +71,8 @@ class FeedbacksController < ApplicationController
   end
 
   def create_redirect
-    if !session[:request_url].include?('last_submitted_hours_and_feedbacks')
-      @volunteer
-    elsif @feedback.assignment?
-      last_submitted_hours_and_feedbacks_assignment_path(@feedbackable)
-    else
-      group_assignment = @feedbackable.group_assignments.where(volunteer: @volunteer).last
-      last_submitted_hours_and_feedbacks_group_assignment_path(group_assignment)
-    end
+    return @volunteer unless params[:last_submitted]
+    polymorphic_path(@feedback.feedbackable_link_target, action: :last_submitted_hours_and_feedbacks)
   end
 
   def feedback_params

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -80,4 +80,12 @@ class Assignment < ApplicationRecord
   def feedbacks_since_last_submitted
     feedbacks.since_last_submitted(submitted_at)
   end
+
+  def assignment?
+    true
+  end
+
+  def group_assignment?
+    false
+  end
 end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -57,6 +57,10 @@ class Assignment < ApplicationRecord
     hours.last
   end
 
+  def polymorph_url_object
+    self
+  end
+
   def to_label
     label_parts.compact.join(' - ')
   end

--- a/app/models/group_assignment.rb
+++ b/app/models/group_assignment.rb
@@ -59,6 +59,10 @@ class GroupAssignment < ApplicationRecord
     group_offer.feedbacks.since_last_submitted(submitted_at)
   end
 
+  def polymorph_url_object
+    group_offer
+  end
+
   private
 
   def dates_updated?

--- a/app/models/group_assignment.rb
+++ b/app/models/group_assignment.rb
@@ -63,6 +63,14 @@ class GroupAssignment < ApplicationRecord
     group_offer
   end
 
+  def assignment?
+    false
+  end
+
+  def group_assignment?
+    true
+  end
+
   private
 
   def dates_updated?

--- a/app/views/application/_last_submitted_hours_and_feedbacks.html.slim
+++ b/app/views/application/_last_submitted_hours_and_feedbacks.html.slim
@@ -1,11 +1,11 @@
 h1 Zuletzt übermittelte Stunden und Feedbacks
 
-h2 Stunden
-
+h2.m-b-20 Einsatz
+p= link_to confirmable.to_label, polymorphic_path([confirmable.volunteer, confirmable]), target: '_blank'
+h3 Stunden
 table.table.table-striped
   thead
     tr
-      th= t_attr(:hourable, Hour)
       th= t_attr(:meeting_date, Hour)
       th= t_attr(:duration, Hour)
       th= t_attr(:activity, Hour)
@@ -13,11 +13,6 @@ table.table.table-striped
   tbody
     - hours.each do |record|
       tr
-        td
-          - if record.assignment?
-            = record.hourable.client.contact.full_name
-          - else
-            = record.hourable.to_label
         td= l(record.meeting_date)
         td= "#{record.hours}:#{'%02i' % record.minutes}"
         td= record.activity
@@ -25,12 +20,11 @@ table.table.table-striped
 
 = bootstrap_row_col { button_link t_title(:new, Hour), new_polymorphic_path([confirmable.volunteer, confirmable, Hour], last_submitted: true) }
 
-h2 Feedback Liste
 
+h3 Feedbacks
 table.table.table-striped
   thead
     tr
-      th Einsatz
       th Ziele
       th Erreichtes
       th Fortsetzen, und wenn ja wie
@@ -43,7 +37,6 @@ table.table.table-striped
   tbody
     - feedbacks.each do |record|
       tr
-        td= record.feedbackable.to_label
         td= record.goals
         td= record.achievements
         td= record.future

--- a/app/views/application/_last_submitted_hours_and_feedbacks.html.slim
+++ b/app/views/application/_last_submitted_hours_and_feedbacks.html.slim
@@ -13,12 +13,12 @@ table.table.table-striped
   tbody
     - hours.each do |record|
       tr
-        td= l(record.meeting_date)
+        td= l(record.meeting_date) if record.meeting_date?
         td= "#{record.hours}:#{'%02i' % record.minutes}"
         td= record.activity
         td= record.comments
 
-= bootstrap_row_col { button_link t_title(:new, Hour), new_polymorphic_path([confirmable.volunteer, confirmable, Hour], last_submitted: true) }
+p= button_link t_title(:new, Hour), new_polymorphic_path([confirmable.volunteer, confirmable, Hour], last_submitted: true)
 
 
 h3 Feedbacks
@@ -43,7 +43,7 @@ table.table.table-striped
         td= record.comments
         td= t(record.conversation)
 
-= bootstrap_row_col { button_link t_title(:new, Feedback), new_polymorphic_path([confirmable.volunteer, confirmable.polymorph_url_object, Feedback], last_submitted: true) }
+p= button_link t_title(:new, Feedback), new_polymorphic_path([confirmable.volunteer, confirmable.polymorph_url_object, Feedback], last_submitted: true)
 
-p.text-center Ich bestätige, dass ich alle meine Stunden und Feedbacks bis zum heutigen Datum erfasst habe.
+p.text-center Ich bestätige, dass ich alle mein e Stunden und Feedbacks bis zum heutigen Datum erfasst habe.
 p.text-center= button_link 'Bestätigen', polymorphic_path(confirmable, action: :update_submitted_at)

--- a/app/views/application/_last_submitted_hours_and_feedbacks.html.slim
+++ b/app/views/application/_last_submitted_hours_and_feedbacks.html.slim
@@ -1,4 +1,6 @@
-h1 Stunden Liste
+h1 Zuletzt übermittelte Stunden und Feedbacks
+
+h2 Stunden
 
 table.table.table-striped
   thead
@@ -23,7 +25,7 @@ table.table.table-striped
 
 = bootstrap_row_col { button_link t_title(:new, Hour), new_polymorphic_path([confirmable.volunteer, confirmable, Hour], last_submitted: true) }
 
-h1 Feedback Liste
+h2 Feedback Liste
 
 table.table.table-striped
   thead

--- a/app/views/application/_last_submitted_hours_and_feedbacks.html.slim
+++ b/app/views/application/_last_submitted_hours_and_feedbacks.html.slim
@@ -45,10 +45,5 @@ table.table.table-striped
 
 = bootstrap_row_col { button_link t_title(:new, Feedback), new_polymorphic_path([confirmable.volunteer, confirmable.polymorph_url_object, Feedback], last_submitted: true) }
 
-.row
-  .col-xs-12.text-center
-    p Ich bestätige, dass ich alle meine Stunden und Feedbacks bis zum heutigen Datum erfasst habe.
-  - if confirmable.class == Assignment
-    .col-xs-12.text-center= button_link 'Bestätigen', update_submitted_at_assignment_path(confirmable)
-  - else
-    .col-xs-12.text-center= button_link 'Bestätigen', update_submitted_at_group_assignment_path(confirmable)
+p.text-center Ich bestätige, dass ich alle meine Stunden und Feedbacks bis zum heutigen Datum erfasst habe.
+p.text-center= button_link 'Bestätigen', polymorphic_path(confirmable, action: :update_submitted_at)

--- a/app/views/application/_last_submitted_hours_and_feedbacks.html.slim
+++ b/app/views/application/_last_submitted_hours_and_feedbacks.html.slim
@@ -45,5 +45,5 @@ table.table.table-striped
 
 p= button_link t_title(:new, Feedback), new_polymorphic_path([confirmable.volunteer, confirmable.polymorph_url_object, Feedback], last_submitted: true)
 
-p.text-center Ich bestätige, dass ich alle mein e Stunden und Feedbacks bis zum heutigen Datum erfasst habe.
-p.text-center= button_link 'Bestätigen', polymorphic_path(confirmable, action: :update_submitted_at)
+.text-center Ich bestätige, dass ich alle meine Stunden und Feedbacks bis zum heutigen Datum erfasst habe.
+.text-center= button_link 'Bestätigen', polymorphic_path(confirmable, action: :update_submitted_at)

--- a/app/views/application/_last_submitted_hours_and_feedbacks.html.slim
+++ b/app/views/application/_last_submitted_hours_and_feedbacks.html.slim
@@ -35,7 +35,11 @@ table.table.table-striped
       th Erreichtes
       th Fortsetzen, und wenn ja wie
       th= t_attr(:comments, Feedback)
-      th= t_attr(:conversation, Feedback)
+      th
+        - if current_user.volunteer?
+          'Wünsche Gespräch mit Freiwillgenverantwortilchen
+        - else
+          'Wünscht Gespräch
   tbody
     - feedbacks.each do |record|
       tr

--- a/app/views/application/_last_submitted_hours_and_feedbacks.html.slim
+++ b/app/views/application/_last_submitted_hours_and_feedbacks.html.slim
@@ -21,7 +21,7 @@ table.table.table-striped
         td= record.activity
         td= record.comments
 
-= bootstrap_row_col { button_link t_title(:new, Hour), new_polymorphic_path([confirmable.volunteer, Hour]) }
+= bootstrap_row_col { button_link t_title(:new, Hour), new_polymorphic_path([confirmable.volunteer, confirmable, Hour], last_submitted: true) }
 
 h1 Feedback Liste
 
@@ -44,10 +44,7 @@ table.table.table-striped
         td= record.comments
         td= t(record.conversation)
 
-- if confirmable.class == Assignment
-  = bootstrap_row_col { button_link t_title(:new, Feedback), new_polymorphic_path([confirmable.volunteer, confirmable, Feedback]) }
-- else
-  = bootstrap_row_col { button_link t_title(:new, Feedback), new_polymorphic_path([confirmable.volunteer, confirmable.group_offer, Feedback]) }
+= bootstrap_row_col { button_link t_title(:new, Feedback), new_polymorphic_path([confirmable.volunteer, confirmable.polymorph_url_object, Feedback], last_submitted: true) }
 
 .row
   .col-xs-12.text-center

--- a/app/views/application/_last_submitted_hours_and_feedbacks.html.slim
+++ b/app/views/application/_last_submitted_hours_and_feedbacks.html.slim
@@ -30,10 +30,10 @@ h2 Feedback Liste
 table.table.table-striped
   thead
     tr
-      th= t_attr(:feedback_activity, Feedback)
-      th= t_attr(:goals, Feedback)
-      th= t_attr(:achievements, Feedback)
-      th= t_attr(:future, Feedback)
+      th Einsatz
+      th Ziele
+      th Erreichtes
+      th Fortsetzen, und wenn ja wie
       th= t_attr(:comments, Feedback)
       th= t_attr(:conversation, Feedback)
   tbody

--- a/app/views/feedbacks/_form.html.slim
+++ b/app/views/feedbacks/_form.html.slim
@@ -1,5 +1,5 @@
 - if @feedbackable.present?
-  = simple_form_for [@volunteer, @feedbackable, @feedback] do |f|
+  = simple_form_for([@volunteer, @feedbackable, @feedback], url: polymorphic_path([@volunteer, @feedbackable, @feedback], last_submitted: params[:last_submitted])) do |f|
     = simple_error_notice f
 
     = render 'main_fields', f: f

--- a/app/views/hours/_form.html.slim
+++ b/app/views/hours/_form.html.slim
@@ -1,11 +1,14 @@
-= simple_form_for [@volunteer, @hour] do |f|
+= simple_form_for([@volunteer, @hour.hourable, @hour], url:  polymorphic_path([@volunteer, @hour.hourable, @hour], last_submitted: params[:last_submitted])) do |f|
   = simple_error_notice f
   = f.hidden_field :volunteer_id, value: params[:volunteer_id] || @hour.volunteer.id
 
-  .row
-    .col-xs-12
-      = f.input :hourable_id_and_type, as: :select, collection: @volunteer.assignment_group_offer_collection
-
+  - if @hour.hourable.present?
+    h3 Einsatz
+    p.m-b-20= @hour.hourable.to_label
+  - else
+    .row
+      .col-xs-12
+        = f.input :hourable_id_and_type, as: :select, collection: @volunteer.assignment_group_offer_collection
 
   .row
     .col-xs-12

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,8 +7,13 @@ Rails.application.routes.draw do
     put :update_submitted_at, on: :member
   end
 
+<<<<<<< HEAD
   concern :mark_submitted_at do
     put :mark_as_done, on: :member
+=======
+  concern :hours_resources do
+    resources :hours
+>>>>>>> fixing routes and use of referer as redirect as redirect back url and others:
   end
 
   concern :assignment_feedbacks do
@@ -37,14 +42,16 @@ Rails.application.routes.draw do
   resources :volunteers do
     get :find_client, on: :member, to: 'assignments#find_client'
     get :seeking_clients, on: :collection
-    resources :assignments, concerns: :assignment_feedbacks
     resources :billing_expenses, except: [:edit, :update]
     resources :certificates
+    resources :group_assignments, concerns: :hours_resources
     resources :group_offers, concerns: :assignment_feedbacks
     resources :hours
     resources :journals, except: [:show]
+    resources :assignments, concerns: [:assignment_feedbacks, :hours_resources]
   end
-
+  resources :group_assignments, only: [:show], concerns: [:update_submitted_at, :hours_resources]
+  resources :assignments, concerns: :update_submitted_at
   resources :group_offers do
     get :archived, on: :collection
     put :change_active_state, on: :member

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,13 +7,12 @@ Rails.application.routes.draw do
     put :update_submitted_at, on: :member
   end
 
-<<<<<<< HEAD
   concern :mark_submitted_at do
     put :mark_as_done, on: :member
-=======
+  end
+
   concern :hours_resources do
     resources :hours
->>>>>>> fixing routes and use of referer as redirect as redirect back url and others:
   end
 
   concern :assignment_feedbacks do


### PR DESCRIPTION

- [x] clicking on new hour link leads to hour form with group-/assignment allready
  selected, no dropdown, so user can't accidently give feedback for wrong Einsatz
- [x] use of referer for redirect back after creation has been removed and replaced
  with something that makes use of get parameter

# [Story in Trello](https://trello.com/c/NrDqFEoE/112-bugfix-last-submitted-hours-and-feedbacks-buggy-new-hour-form-and-use-of-referrer-as-redirect)

## Done?

### Done for approval?

* [ ] Acceptance criteria are met
* [ ] Code quality checks are green
* [ ] Readme updated if needed
* [ ] Story under test
* [ ] Mobile works
* [ ] Seeds created
* [ ] Code is reviewed

### Done after the merge?

* [ ] Deployed to staging after the merge
* [ ] Tested manually on staging
