### PR TITLE
Fixes: Find client button should appear once

### DIFF
--- a/app/views/volunteers/_volunteer.html.slim
+++ b/app/views/volunteers/_volunteer.html.slim
@@ -25,10 +25,8 @@ tr
     td= render 'index_actions', subject: volunteer
   td
     - if volunteer.seeking_clients?
-      = button_link t('find_client'), find_client_volunteer_path(id: volunteer)
+      = button_link 'Klient/in finden', find_client_volunteer_path(id: volunteer)
     - elsif volunteer.assignments.any? || volunteer.group_assignments.any?
       = button_link t('.show_assignments'), volunteer_path(volunteer, anchor: 'assignments')
     - else
       = t('not_assignable')
-  - if action_name == 'seeking_clients'
-    td = button_link t('find_client'), find_client_volunteer_path(id: volunteer)

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -716,7 +716,6 @@ de:
         one: 'Konnte %{resource} nicht speichern: ein Fehler.'
         other: 'Konnte %{resource} nicht speichern: %{count} Fehler.'
   "false": Nein
-  find_client: Klient/in finden
   forgot_password: Passwort vergessen?
   get_back: Wir werden uns bald bei Ihnen melden.
   helpers:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -557,7 +557,6 @@ en:
         one: '1 error prohibited this %{resource} from being saved:'
         other: '%{count} errors prohibited this %{resource} from being saved:'
   "false": "No"
-  find_client: Find client
   forgot_password: Forgot your password?
   get_back: We will soon get back to you.
   helpers:


### PR DESCRIPTION
# [Story in Trello](https://trello.com/c/1BnwFqpE/128-bug-find-client-button-is-shown-twice-on-seeking-clients-page)

## Done?

### Done for approval?

* [x] Acceptance criteria are met
* [x] Code quality checks are green
* ~[ ] Readme updated if needed~
* ~[ ] Story under test~
* ~[ ] Mobile works~
* ~[ ] Seeds created~
* [x] Code is reviewed

### Done after the merge?

* [ ] Deployed to staging after the merge
* [ ] Tested manually on staging
